### PR TITLE
fix: define missing _create_error_chat_response helper

### DIFF
--- a/src/api/routers/chat.py
+++ b/src/api/routers/chat.py
@@ -585,6 +585,24 @@ def _create_simple_fallback_response(message: str, session_id: str) -> ChatRespo
     )
 
 
+def _create_error_chat_response(
+    user_message: str,
+    error_message: str,
+    error_type: str,
+    session_id: str,
+    confidence: float,
+) -> ChatResponse:
+    """Create a ChatResponse for error conditions."""
+    return ChatResponse(
+        reply=user_message,
+        route="error",
+        intent="error",
+        session_id=session_id,
+        confidence=confidence,
+        structured_data={"error": error_message, "error_type": error_type},
+    )
+
+
 class ConversationSummaryRequest(BaseModel):
     session_id: str
 


### PR DESCRIPTION
## Summary

`_create_error_chat_response` was called in four error-handling paths (timeout, connection, validation, and general exceptions) in `src/api/routers/chat.py` but was never defined, causing a `NameError` crash on every error path.

## Fix

Add the missing function returning a `ChatResponse` with `route="error"` and the error details in `structured_data`.

## Test plan

- [x] Trigger a timeout during a chat request and confirm a clean error response is returned
- [x] Trigger a connection error and confirm no `NameError` is raised
- [x] Trigger a general exception and confirm the error response is returned correctly

Fixes #30