### PR TITLE
Add Red Hat OpenShift deployment support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -172,8 +172,9 @@ deploy/
 monitoring/
 nginx.conf
 
-# Scripts (not needed in runtime, only source code)
+# Scripts (not copied by upstream Dockerfile, but needed by OpenShift Dockerfile)
 scripts/
+!scripts/
 
 # Type checking and linting
 .mypy_cache/
@@ -194,6 +195,8 @@ setup.cfg
 MANIFEST.in
 requirements*.txt
 !requirements.docker.txt
+# requirements.txt is needed by openshift/Dockerfile.backend (full dependency list)
+!requirements.txt
 
 # Celery
 celerybeat-schedule

--- a/Dockerfile.backend-openshift
+++ b/Dockerfile.backend-openshift
@@ -1,0 +1,67 @@
+# Backend Dockerfile for OpenShift
+# Builds the Python/FastAPI backend only (no frontend).
+#
+# OpenShift fixes vs root Dockerfile.backend:
+#   1. requirements.txt instead of requirements.docker.txt (14 missing packages)
+#   2. Explicit COPYs for data/, scripts/, README.md (missing from upstream)
+
+# =============================================================================
+# Backend Dependencies Stage
+# =============================================================================
+FROM python:3.11-slim AS backend-deps
+
+WORKDIR /app
+
+RUN apt-get update && apt-get install -y \
+    g++ \
+    gcc \
+    git \
+    && rm -rf /var/lib/apt/lists/*
+
+# Fix: requirements.docker.txt is missing tiktoken, psycopg, pandas, nemoguardrails, etc.
+COPY requirements.txt ./requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
+
+# =============================================================================
+# Final Runtime Stage
+# =============================================================================
+FROM python:3.11-slim AS final
+
+WORKDIR /app
+
+RUN apt-get update && apt-get install -y \
+    curl \
+    git \
+    poppler-utils \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=backend-deps /usr/local/lib/python3.11/site-packages /usr/local/lib/python3.11/site-packages
+COPY --from=backend-deps /usr/local/bin /usr/local/bin
+
+# Fix: upstream Dockerfile only copies src/ and data/config/guardrails/, missing
+# data/config/agents/ (agent personas), data/postgres/migrations/, scripts/,
+# and README.md. Docker Compose bind-mounts the entire repo (volumes: [".:/app"]),
+# so we must COPY everything the backend needs at runtime.
+COPY src/ ./src/
+COPY data/ ./data/
+COPY scripts/ ./scripts/
+COPY README.md ./
+
+ARG VERSION=0.0.0
+ARG GIT_SHA=unknown
+ARG BUILD_TIME=unknown
+
+ENV VERSION=$VERSION
+ENV GIT_SHA=$GIT_SHA
+ENV BUILD_TIME=$BUILD_TIME
+ENV DOCKER_IMAGE=warehouse-assistant:$VERSION
+ENV PYTHONPATH=/app
+ENV PYTHONUNBUFFERED=1
+
+# No USER directive - OpenShift restricted-v2 assigns a random UID with GID 0.
+# Writable paths (data/uploads/) are mounted as emptyDir volumes in the
+# Helm chart, so no chown/chmod needed on the image filesystem.
+
+EXPOSE 8001
+
+CMD ["uvicorn", "src.api.app:app", "--host", "0.0.0.0", "--port", "8001"]

--- a/Dockerfile.frontend-openshift
+++ b/Dockerfile.frontend-openshift
@@ -1,0 +1,43 @@
+# Frontend Dockerfile for OpenShift
+# Builds React app and serves with nginx-unprivileged.
+#
+# OpenShift fixes vs root Dockerfile.frontend:
+#   1. Production build (npm run build) instead of dev server (npm start)
+#   2. nginx-unprivileged on port 8080 (OpenShift restricted-v2 compatible)
+#   3. npm install instead of npm ci (unresolvable peer dep conflicts)
+
+# =============================================================================
+# Build Stage
+# =============================================================================
+FROM node:20-alpine AS builder
+
+WORKDIR /app
+
+COPY src/ui/web/package*.json ./
+
+# npm install instead of npm ci - react-scripts has unresolvable peer dep
+# conflicts (ajv@6 vs ajv@8, picomatch@2 vs picomatch@4) that make npm ci
+# fail regardless of lock file state. See docs/deployment/openshift-deployment.md for details.
+RUN npm install
+
+COPY src/ui/web/ ./
+
+ARG VERSION=0.0.0
+ARG GIT_SHA=unknown
+ARG BUILD_TIME=unknown
+
+ENV REACT_APP_VERSION=$VERSION
+ENV REACT_APP_GIT_SHA=$GIT_SHA
+ENV REACT_APP_BUILD_TIME=$BUILD_TIME
+
+RUN npm run build
+
+# =============================================================================
+# Production Stage - nginx-unprivileged (OpenShift compatible)
+# =============================================================================
+FROM nginxinc/nginx-unprivileged:1.25-alpine
+
+COPY --from=builder /app/build /usr/share/nginx/html
+
+# nginx-unprivileged listens on 8080 by default - no config change needed
+EXPOSE 8080

--- a/README.md
+++ b/README.md
@@ -689,6 +689,7 @@ pytest tests/integration/
 - **MCP Integration**: [docs/architecture/mcp-integration.md](docs/architecture/mcp-integration.md)
 - **Forecasting**: [docs/forecasting/](docs/forecasting/)
 - **Deployment**: [DEPLOYMENT.md](DEPLOYMENT.md) - Complete deployment guide with Docker and Kubernetes options
+- **OpenShift Deployment**: [docs/deployment/openshift-deployment.md](docs/deployment/openshift-deployment.md) - Red Hat OpenShift AI deployment
 
 ## Contributing
 

--- a/deploy/helm/wosa/.helmignore
+++ b/deploy/helm/wosa/.helmignore
@@ -1,0 +1,15 @@
+.DS_Store
+.git/
+.gitignore
+.bzr/
+.hg/
+.svn/
+*.swp
+*.bak
+*.tmp
+*~
+.idea/
+.vscode/
+.github/
+.env
+*.local

--- a/deploy/helm/wosa/Chart.yaml
+++ b/deploy/helm/wosa/Chart.yaml
@@ -1,0 +1,28 @@
+apiVersion: v2
+name: wosa
+description: |
+  A Helm chart for deploying the Multi-Agent Intelligent Warehouse (WOSA)
+  on Kubernetes and OpenShift. This AI-powered application provides intelligent
+  warehouse operations, safety monitoring, equipment tracking, document
+  processing, and demand forecasting using NVIDIA NIM services.
+
+type: application
+version: 1.0.0
+appVersion: "1.0.0"
+
+keywords:
+  - nvidia
+  - ai
+  - warehouse
+  - multi-agent
+  - langgraph
+  - milvus
+  - openshift
+
+home: https://github.com/NVIDIA-AI-Blueprints/Multi-Agent-Intelligent-Warehouse
+sources:
+  - https://github.com/NVIDIA-AI-Blueprints/Multi-Agent-Intelligent-Warehouse
+
+maintainers:
+  - name: NVIDIA
+    url: https://nvidia.com

--- a/deploy/helm/wosa/dashboards/warehouse-operations-openshift.json
+++ b/deploy/helm/wosa/dashboards/warehouse-operations-openshift.json
@@ -1,0 +1,243 @@
+{
+  "dashboard": {
+    "id": null,
+    "panels": [
+      {
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 0,
+          "y": 0
+        },
+        "id": 1,
+        "targets": [
+          {
+            "expr": "sum(rate(warehouse_tasks_completed_total[5m])) / sum(rate(warehouse_tasks_created_total[5m])) * 100",
+            "legendFormat": "Completion Rate %",
+            "refId": "A"
+          }
+        ],
+        "title": "Task Completion Rate",
+        "type": "graph",
+        "yAxes": [
+          {
+            "label": "Percentage",
+            "max": 100,
+            "min": 0
+          }
+        ]
+      },
+      {
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 12,
+          "y": 0
+        },
+        "id": 2,
+        "targets": [
+          {
+            "expr": "sum(warehouse_tasks_by_status) by (status)",
+            "legendFormat": "{{status}}",
+            "refId": "A"
+          }
+        ],
+        "title": "Task Status Distribution",
+        "type": "piechart"
+      },
+      {
+        "gridPos": {
+          "h": 8,
+          "w": 24,
+          "x": 0,
+          "y": 8
+        },
+        "id": 3,
+        "targets": [
+          {
+            "expr": "sum(rate(warehouse_tasks_completed_total{worker_id!=\"\"}[1h])) by (worker_id)",
+            "legendFormat": "{{worker_id}}",
+            "refId": "A"
+          }
+        ],
+        "title": "Worker Productivity",
+        "type": "graph",
+        "yAxes": [
+          {
+            "label": "Tasks/hour",
+            "min": 0
+          }
+        ]
+      },
+      {
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 0,
+          "y": 16
+        },
+        "id": 4,
+        "targets": [
+          {
+            "expr": "sum(warehouse_equipment_utilization_percent) by (equipment_id, equipment_type)",
+            "legendFormat": "{{equipment_id}} - {{equipment_type}}",
+            "refId": "A"
+          }
+        ],
+        "title": "Equipment Utilization",
+        "type": "graph",
+        "yAxes": [
+          {
+            "label": "Utilization %",
+            "max": 100,
+            "min": 0
+          }
+        ]
+      },
+      {
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "unit": "short"
+          }
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 12,
+          "y": 16
+        },
+        "id": 5,
+        "targets": [
+          {
+            "expr": "sum(warehouse_equipment_status{status=\"operational\"})",
+            "legendFormat": "Operational",
+            "refId": "A"
+          },
+          {
+            "expr": "sum(warehouse_equipment_status{status=\"maintenance\"})",
+            "legendFormat": "Maintenance",
+            "refId": "B"
+          },
+          {
+            "expr": "sum(warehouse_equipment_status{status=\"offline\"})",
+            "legendFormat": "Offline",
+            "refId": "C"
+          }
+        ],
+        "title": "Equipment Status",
+        "type": "stat"
+      },
+      {
+        "gridPos": {
+          "h": 8,
+          "w": 24,
+          "x": 0,
+          "y": 24
+        },
+        "id": 6,
+        "targets": [
+          {
+            "expr": "histogram_quantile(0.95, sum(rate(warehouse_order_processing_duration_seconds_bucket[5m])) by (le))",
+            "legendFormat": "95th percentile",
+            "refId": "A"
+          },
+          {
+            "expr": "histogram_quantile(0.50, sum(rate(warehouse_order_processing_duration_seconds_bucket[5m])) by (le))",
+            "legendFormat": "50th percentile",
+            "refId": "B"
+          }
+        ],
+        "title": "Order Processing Time",
+        "type": "graph",
+        "yAxes": [
+          {
+            "label": "Seconds",
+            "min": 0
+          }
+        ]
+      },
+      {
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 0,
+          "y": 32
+        },
+        "id": 7,
+        "targets": [
+          {
+            "expr": "sum(rate(warehouse_inventory_movements_total[1h])) by (movement_type)",
+            "legendFormat": "{{movement_type}}",
+            "refId": "A"
+          }
+        ],
+        "title": "Inventory Turnover Rate",
+        "type": "graph",
+        "yAxes": [
+          {
+            "label": "Movements/hour",
+            "min": 0
+          }
+        ]
+      },
+      {
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "thresholds": {
+              "steps": [
+                {
+                  "color": "red",
+                  "value": 0
+                },
+                {
+                  "color": "yellow",
+                  "value": 90
+                },
+                {
+                  "color": "green",
+                  "value": 95
+                }
+              ]
+            },
+            "unit": "percent"
+          }
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 12,
+          "y": 32
+        },
+        "id": 8,
+        "targets": [
+          {
+            "expr": "avg(warehouse_pick_accuracy_percent)",
+            "legendFormat": "Accuracy %",
+            "refId": "A"
+          }
+        ],
+        "title": "Pick Accuracy Rate",
+        "type": "stat"
+      }
+    ],
+    "refresh": "30s",
+    "style": "dark",
+    "tags": [
+      "warehouse",
+      "operations",
+      "detailed"
+    ],
+    "time": {
+      "from": "now-6h",
+      "to": "now"
+    },
+    "timezone": "browser",
+    "title": "Warehouse Operations - Detailed View"
+  }
+}

--- a/deploy/helm/wosa/dashboards/warehouse-overview-openshift.json
+++ b/deploy/helm/wosa/dashboards/warehouse-overview-openshift.json
@@ -1,0 +1,298 @@
+{
+  "dashboard": {
+    "id": null,
+    "panels": [
+      {
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [
+              {
+                "options": {
+                  "0": {
+                    "text": "DOWN"
+                  },
+                  "1": {
+                    "text": "UP"
+                  }
+                },
+                "type": "value"
+              }
+            ],
+            "thresholds": {
+              "steps": [
+                {
+                  "color": "red",
+                  "value": 0
+                },
+                {
+                  "color": "green",
+                  "value": 1
+                }
+              ]
+            }
+          }
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 24,
+          "x": 0,
+          "y": 0
+        },
+        "id": 1,
+        "targets": [
+          {
+            "expr": "up{job=\"warehouse-api\"}",
+            "legendFormat": "API Server",
+            "refId": "A"
+          },
+          {
+            "expr": "up{job=\"postgres\"}",
+            "legendFormat": "Database",
+            "refId": "B"
+          },
+          {
+            "expr": "up{job=\"redis\"}",
+            "legendFormat": "Redis",
+            "refId": "C"
+          },
+          {
+            "expr": "up{job=\"milvus\"}",
+            "legendFormat": "Milvus",
+            "refId": "D"
+          }
+        ],
+        "title": "System Health Status",
+        "type": "stat"
+      },
+      {
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 0,
+          "y": 8
+        },
+        "id": 2,
+        "targets": [
+          {
+            "expr": "sum(rate(http_requests_total{job=\"warehouse-api\"}[5m])) by (method, endpoint)",
+            "legendFormat": "{{method}} {{endpoint}}",
+            "refId": "A"
+          }
+        ],
+        "title": "API Request Rate",
+        "type": "graph",
+        "yAxes": [
+          {
+            "label": "Requests/sec",
+            "min": 0
+          }
+        ]
+      },
+      {
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 12,
+          "y": 8
+        },
+        "id": 3,
+        "targets": [
+          {
+            "expr": "histogram_quantile(0.95, sum(rate(http_request_duration_seconds_bucket{job=\"warehouse-api\"}[5m])) by (le))",
+            "legendFormat": "95th percentile",
+            "refId": "A"
+          },
+          {
+            "expr": "histogram_quantile(0.50, sum(rate(http_request_duration_seconds_bucket{job=\"warehouse-api\"}[5m])) by (le))",
+            "legendFormat": "50th percentile",
+            "refId": "B"
+          }
+        ],
+        "title": "API Response Time",
+        "type": "graph",
+        "yAxes": [
+          {
+            "label": "Seconds",
+            "min": 0
+          }
+        ]
+      },
+      {
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "unit": "short"
+          }
+        },
+        "gridPos": {
+          "h": 4,
+          "w": 6,
+          "x": 0,
+          "y": 16
+        },
+        "id": 4,
+        "targets": [
+          {
+            "expr": "sum(warehouse_active_users)",
+            "legendFormat": "Active Users",
+            "refId": "A"
+          }
+        ],
+        "title": "Active Users",
+        "type": "stat"
+      },
+      {
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "unit": "short"
+          }
+        },
+        "gridPos": {
+          "h": 4,
+          "w": 6,
+          "x": 6,
+          "y": 16
+        },
+        "id": 5,
+        "targets": [
+          {
+            "expr": "sum(increase(warehouse_tasks_completed_total[1d]))",
+            "legendFormat": "Tasks Completed",
+            "refId": "A"
+          }
+        ],
+        "title": "Tasks Completed Today",
+        "type": "stat"
+      },
+      {
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "thresholds": {
+              "steps": [
+                {
+                  "color": "green",
+                  "value": 0
+                },
+                {
+                  "color": "yellow",
+                  "value": 5
+                },
+                {
+                  "color": "red",
+                  "value": 10
+                }
+              ]
+            }
+          }
+        },
+        "gridPos": {
+          "h": 4,
+          "w": 6,
+          "x": 12,
+          "y": 16
+        },
+        "id": 6,
+        "targets": [
+          {
+            "expr": "sum(warehouse_inventory_alerts_total)",
+            "legendFormat": "Active Alerts",
+            "refId": "A"
+          }
+        ],
+        "title": "Inventory Alerts",
+        "type": "stat"
+      },
+      {
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "thresholds": {
+              "steps": [
+                {
+                  "color": "green",
+                  "value": 0
+                },
+                {
+                  "color": "red",
+                  "value": 1
+                }
+              ]
+            }
+          }
+        },
+        "gridPos": {
+          "h": 4,
+          "w": 6,
+          "x": 18,
+          "y": 16
+        },
+        "id": 7,
+        "targets": [
+          {
+            "expr": "sum(warehouse_safety_incidents_total)",
+            "legendFormat": "Total Incidents",
+            "refId": "A"
+          }
+        ],
+        "title": "Safety Incidents",
+        "type": "stat"
+      },
+      {
+        "gridPos": {
+          "h": 8,
+          "w": 24,
+          "x": 0,
+          "y": 20
+        },
+        "id": 8,
+        "targets": [
+          {
+            "expr": "100 - (avg (rate(node_cpu_seconds_total{mode=\"idle\"}[5m])) * 100)",
+            "legendFormat": "CPU Usage %",
+            "refId": "A"
+          },
+          {
+            "expr": "(1 - (avg(node_memory_MemAvailable_bytes) / avg(node_memory_MemTotal_bytes))) * 100",
+            "legendFormat": "Memory Usage %",
+            "refId": "B"
+          }
+        ],
+        "title": "System Resource Usage",
+        "type": "graph",
+        "yAxes": [
+          {
+            "label": "Percentage",
+            "max": 100,
+            "min": 0
+          }
+        ]
+      }
+    ],
+    "refresh": "30s",
+    "style": "dark",
+    "tags": [
+      "warehouse",
+      "operations",
+      "overview"
+    ],
+    "time": {
+      "from": "now-1h",
+      "to": "now"
+    },
+    "timezone": "browser",
+    "title": "Warehouse Operational Assistant - Overview"
+  }
+}

--- a/deploy/helm/wosa/dashboards/warehouse-safety-openshift.json
+++ b/deploy/helm/wosa/dashboards/warehouse-safety-openshift.json
@@ -1,0 +1,307 @@
+{
+  "dashboard": {
+    "id": null,
+    "panels": [
+      {
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 0,
+          "y": 0
+        },
+        "id": 1,
+        "targets": [
+          {
+            "expr": "sum(increase(warehouse_safety_incidents_total[1h])) by (incident_type)",
+            "legendFormat": "{{incident_type}}",
+            "refId": "A"
+          }
+        ],
+        "title": "Safety Incidents by Type",
+        "type": "graph",
+        "yAxes": [
+          {
+            "label": "Incidents/hour",
+            "min": 0
+          }
+        ]
+      },
+      {
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 12,
+          "y": 0
+        },
+        "id": 2,
+        "targets": [
+          {
+            "expr": "avg(warehouse_safety_score)",
+            "legendFormat": "Safety Score",
+            "refId": "A"
+          }
+        ],
+        "title": "Safety Score Trend",
+        "type": "graph",
+        "yAxes": [
+          {
+            "label": "Score",
+            "max": 100,
+            "min": 0
+          }
+        ]
+      },
+      {
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "unit": "short"
+          }
+        },
+        "gridPos": {
+          "h": 4,
+          "w": 24,
+          "x": 0,
+          "y": 8
+        },
+        "id": 3,
+        "targets": [
+          {
+            "expr": "sum(warehouse_compliance_checks_passed)",
+            "legendFormat": "Passed",
+            "refId": "A"
+          },
+          {
+            "expr": "sum(warehouse_compliance_checks_failed)",
+            "legendFormat": "Failed",
+            "refId": "B"
+          },
+          {
+            "expr": "sum(warehouse_compliance_checks_pending)",
+            "legendFormat": "Pending",
+            "refId": "C"
+          }
+        ],
+        "title": "Compliance Checklist Status",
+        "type": "stat"
+      },
+      {
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "thresholds": {
+              "steps": [
+                {
+                  "color": "red",
+                  "value": 0
+                },
+                {
+                  "color": "yellow",
+                  "value": 80
+                },
+                {
+                  "color": "green",
+                  "value": 95
+                }
+              ]
+            },
+            "unit": "percent"
+          }
+        },
+        "gridPos": {
+          "h": 4,
+          "w": 8,
+          "x": 0,
+          "y": 12
+        },
+        "id": 4,
+        "targets": [
+          {
+            "expr": "avg(warehouse_ppe_compliance_percent)",
+            "legendFormat": "PPE Compliance %",
+            "refId": "A"
+          }
+        ],
+        "title": "PPE Compliance Rate",
+        "type": "stat"
+      },
+      {
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "thresholds": {
+              "steps": [
+                {
+                  "color": "red",
+                  "value": 0
+                },
+                {
+                  "color": "yellow",
+                  "value": 70
+                },
+                {
+                  "color": "green",
+                  "value": 90
+                }
+              ]
+            },
+            "unit": "percent"
+          }
+        },
+        "gridPos": {
+          "h": 4,
+          "w": 8,
+          "x": 8,
+          "y": 12
+        },
+        "id": 5,
+        "targets": [
+          {
+            "expr": "avg(warehouse_training_completion_percent)",
+            "legendFormat": "Training Completion %",
+            "refId": "A"
+          }
+        ],
+        "title": "Training Completion Rate",
+        "type": "stat"
+      },
+      {
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "thresholds": {
+              "steps": [
+                {
+                  "color": "green",
+                  "value": 0
+                },
+                {
+                  "color": "yellow",
+                  "value": 3
+                },
+                {
+                  "color": "red",
+                  "value": 5
+                }
+              ]
+            },
+            "unit": "short"
+          }
+        },
+        "gridPos": {
+          "h": 4,
+          "w": 8,
+          "x": 16,
+          "y": 12
+        },
+        "id": 6,
+        "targets": [
+          {
+            "expr": "sum(increase(warehouse_near_miss_events_total[24h]))",
+            "legendFormat": "Near Misses (24h)",
+            "refId": "A"
+          }
+        ],
+        "title": "Near Miss Events",
+        "type": "stat"
+      },
+      {
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 0,
+          "y": 16
+        },
+        "id": 7,
+        "targets": [
+          {
+            "expr": "avg(warehouse_temperature_celsius) by (zone)",
+            "legendFormat": "Temperature (\u00b0C)",
+            "refId": "A"
+          },
+          {
+            "expr": "avg(warehouse_humidity_percent) by (zone)",
+            "legendFormat": "Humidity (%)",
+            "refId": "B"
+          }
+        ],
+        "title": "Environmental Conditions",
+        "type": "graph",
+        "yAxes": [
+          {
+            "label": "Value",
+            "min": 0
+          }
+        ]
+      },
+      {
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 12,
+          "y": 16
+        },
+        "id": 8,
+        "targets": [
+          {
+            "expr": "histogram_quantile(0.95, sum(rate(warehouse_emergency_response_duration_seconds_bucket[5m])) by (le))",
+            "legendFormat": "95th percentile",
+            "refId": "A"
+          },
+          {
+            "expr": "histogram_quantile(0.50, sum(rate(warehouse_emergency_response_duration_seconds_bucket[5m])) by (le))",
+            "legendFormat": "50th percentile",
+            "refId": "B"
+          }
+        ],
+        "title": "Emergency Response Time",
+        "type": "graph",
+        "yAxes": [
+          {
+            "label": "Seconds",
+            "min": 0
+          }
+        ]
+      },
+      {
+        "gridPos": {
+          "h": 8,
+          "w": 24,
+          "x": 0,
+          "y": 24
+        },
+        "id": 9,
+        "targets": [
+          {
+            "expr": "sum(warehouse_safety_violations_by_category) by (category)",
+            "legendFormat": "{{category}}",
+            "refId": "A"
+          }
+        ],
+        "title": "Safety Violations by Category",
+        "type": "piechart"
+      }
+    ],
+    "refresh": "30s",
+    "style": "dark",
+    "tags": [
+      "warehouse",
+      "safety",
+      "compliance"
+    ],
+    "time": {
+      "from": "now-24h",
+      "to": "now"
+    },
+    "timezone": "browser",
+    "title": "Warehouse Safety & Compliance"
+  }
+}

--- a/deploy/helm/wosa/templates/NOTES.txt
+++ b/deploy/helm/wosa/templates/NOTES.txt
@@ -1,0 +1,35 @@
+{{- $fullname := include "wosa.fullname" . -}}
+{{- $ns := include "wosa.namespace" . -}}
+{{- $cli := ternary "oc" "kubectl" .Values.openshift.enabled -}}
+
+================================================================================
+  WOSA - Multi-Agent Intelligent Warehouse
+================================================================================
+
+{{- if and .Values.openshift.enabled .Values.openshift.route.enabled }}
+
+Application URL:
+  https://$(oc get route {{ $fullname }} -n {{ $ns }} -o jsonpath='{.spec.host}')
+
+{{- else }}
+
+No Route/Ingress created. Port-forward to access nginx:
+  {{ $cli }} port-forward svc/{{ include "wosa.nginx.name" . }} 8080:{{ .Values.nginx.service.port }} -n {{ $ns }}
+  Then open http://localhost:8080
+
+{{- end }}
+
+Verify pods:
+  {{ $cli }} get pods -n {{ $ns }}
+
+Backend health check:
+{{- if and .Values.openshift.enabled .Values.openshift.route.enabled }}
+  ROUTE=$(oc get route {{ $fullname }} -n {{ $ns }} -o jsonpath='{.spec.host}')
+  curl -k https://${ROUTE}{{ .Values.backend.healthCheck.path }}
+{{- else }}
+  {{ $cli }} port-forward svc/{{ include "wosa.backend.name" . }} 8001:{{ .Values.backend.port }} -n {{ $ns }}
+  curl http://localhost:8001{{ .Values.backend.healthCheck.path }}
+{{- end }}
+
+View logs:
+  {{ $cli }} logs -l app.kubernetes.io/component=backend -n {{ $ns }} --tail=50

--- a/deploy/helm/wosa/templates/_helpers.tpl
+++ b/deploy/helm/wosa/templates/_helpers.tpl
@@ -1,0 +1,139 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "wosa.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "wosa.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+
+{{/*
+Namespace - use .Values.namespace if set, otherwise Release.Namespace
+*/}}
+{{- define "wosa.namespace" -}}
+{{- default .Release.Namespace .Values.namespace }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "wosa.labels" -}}
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{ include "wosa.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: {{ include "wosa.name" . }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "wosa.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "wosa.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Service account name
+*/}}
+{{- define "wosa.serviceAccountName" -}}
+{{- .Values.serviceAccount.name }}
+{{- end }}
+
+{{/*
+Storage class
+*/}}
+{{- define "wosa.storageClass" -}}
+{{- if .Values.storageClass }}
+storageClassName: {{ .Values.storageClass }}
+{{- end }}
+{{- end }}
+
+{{/*
+Image pull secrets - expects list of objects with .name key (Helm/K8s convention)
+Example values.yaml: imagePullSecrets: [{name: my-secret}]
+*/}}
+{{- define "wosa.imagePullSecrets" -}}
+{{- if .Values.imagePullSecrets }}
+imagePullSecrets:
+{{- range .Values.imagePullSecrets }}
+  - name: {{ .name }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Pod security context (restricted-v2)
+*/}}
+{{- define "wosa.podSecurityContext" -}}
+{{- if .Values.securityContext }}
+securityContext:
+  {{- toYaml .Values.securityContext | nindent 2 }}
+{{- end }}
+{{- end }}
+
+{{/*
+Container security context (restricted-v2)
+*/}}
+{{- define "wosa.containerSecurityContext" -}}
+{{- if .Values.containerSecurityContext }}
+securityContext:
+  {{- toYaml .Values.containerSecurityContext | nindent 2 }}
+{{- end }}
+{{- end }}
+
+{{/* Per-service name helpers */}}
+{{- define "wosa.backend.name" -}}
+{{- printf "%s-backend" (include "wosa.fullname" .) }}
+{{- end }}
+
+{{- define "wosa.timescaledb.name" -}}
+{{- printf "%s-timescaledb" (include "wosa.fullname" .) }}
+{{- end }}
+
+{{- define "wosa.redis.name" -}}
+{{- printf "%s-redis" (include "wosa.fullname" .) }}
+{{- end }}
+
+{{- define "wosa.kafka.name" -}}
+{{- printf "%s-kafka" (include "wosa.fullname" .) }}
+{{- end }}
+
+{{- define "wosa.etcd.name" -}}
+{{- printf "%s-etcd" (include "wosa.fullname" .) }}
+{{- end }}
+
+{{- define "wosa.minio.name" -}}
+{{- printf "%s-minio" (include "wosa.fullname" .) }}
+{{- end }}
+
+{{- define "wosa.milvus.name" -}}
+{{- printf "%s-milvus" (include "wosa.fullname" .) }}
+{{- end }}
+
+{{- define "wosa.frontend.name" -}}
+{{- printf "%s-frontend" (include "wosa.fullname" .) }}
+{{- end }}
+
+{{- define "wosa.nginx.name" -}}
+{{- printf "%s-nginx" (include "wosa.fullname" .) }}
+{{- end }}
+
+{{/*
+Secret name
+*/}}
+{{- define "wosa.secret.name" -}}
+{{- printf "%s-secrets" (include "wosa.fullname" .) }}
+{{- end }}
+

--- a/deploy/helm/wosa/templates/backend-deployment.yaml
+++ b/deploy/helm/wosa/templates/backend-deployment.yaml
@@ -1,0 +1,303 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "wosa.backend.name" . }}
+  namespace: {{ include "wosa.namespace" . }}
+  labels:
+    {{- include "wosa.labels" . | nindent 4 }}
+    app.kubernetes.io/component: backend
+spec:
+  replicas: {{ .Values.backend.replicas }}
+  selector:
+    matchLabels:
+      {{- include "wosa.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: backend
+  template:
+    metadata:
+      labels:
+        {{- include "wosa.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: backend
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      serviceAccountName: {{ include "wosa.serviceAccountName" . }}
+      {{- include "wosa.imagePullSecrets" . | nindent 6 }}
+      {{- include "wosa.podSecurityContext" . | nindent 6 }}
+      containers:
+        - name: backend
+          image: "{{ required "image.repository is required" .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.backend.port }}
+              protocol: TCP
+          resources:
+            {{- toYaml .Values.backend.resources | nindent 12 }}
+          {{- include "wosa.containerSecurityContext" . | nindent 10 }}
+          volumeMounts:
+            - name: uploads
+              mountPath: /app/data/uploads
+            - name: forecast-output
+              mountPath: /app/output
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.backend.healthCheck.path }}
+              port: http
+            initialDelaySeconds: {{ .Values.backend.healthCheck.initialDelaySeconds }}
+            periodSeconds: {{ .Values.backend.healthCheck.periodSeconds }}
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.backend.healthCheck.path }}
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 5
+            timeoutSeconds: 3
+          env:
+            # POSTGRES_* must come first - DATABASE_URL below uses $(VAR) substitution
+            # which is order-dependent in Kubernetes (only earlier env entries are expanded).
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "wosa.secret.name" . }}
+                  key: postgres-user
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "wosa.secret.name" . }}
+                  key: postgres-password
+            - name: POSTGRES_DB
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "wosa.secret.name" . }}
+                  key: postgres-db
+            # --- Service discovery ---
+            - name: DB_HOST
+              value: {{ include "wosa.timescaledb.name" . | quote }}
+            - name: DB_PORT
+              value: {{ .Values.backend.env.dbPort | quote }}
+            # sql_retriever uses PGHOST/PGPORT (defaults to localhost:5435)
+            - name: PGHOST
+              value: {{ include "wosa.timescaledb.name" . | quote }}
+            - name: PGPORT
+              value: {{ .Values.backend.env.dbPort | quote }}
+            # health.py builds its own asyncpg URL ignoring DB_HOST/DB_PORT (falls back to
+            # localhost:5435). Set DATABASE_URL explicitly so the health check connects correctly.
+            - name: DATABASE_URL
+              value: "postgresql://$(POSTGRES_USER):$(POSTGRES_PASSWORD)@{{ include "wosa.timescaledb.name" . }}:{{ .Values.backend.env.dbPort }}/$(POSTGRES_DB)"
+            - name: REDIS_HOST
+              value: {{ include "wosa.redis.name" . | quote }}
+            - name: REDIS_PORT
+              value: {{ .Values.backend.env.redisPort | quote }}
+            - name: REDIS_DB
+              value: {{ .Values.backend.env.redisDb | quote }}
+            - name: REDIS_PASSWORD
+              value: ""
+            - name: MILVUS_HOST
+              value: {{ include "wosa.milvus.name" . | quote }}
+            - name: MILVUS_PORT
+              value: {{ .Values.backend.env.milvusPort | quote }}
+            - name: MILVUS_USER
+              value: {{ .Values.backend.env.milvusUser | quote }}
+            - name: MILVUS_PASSWORD
+              value: {{ .Values.backend.env.milvusPassword | quote }}
+            - name: KAFKA_BOOTSTRAP_SERVERS
+              value: {{ printf "%s:%v" (include "wosa.kafka.name" .) .Values.kafka.port | quote }}
+            - name: FORECAST_OUTPUT_DIR
+              value: "/app/output"
+            # --- Non-secret config ---
+            - name: ENVIRONMENT
+              value: {{ .Values.backend.env.environment | quote }}
+            - name: LLM_NIM_URL
+              {{- if .Values.nimOperator.llm.enabled }}
+              value: "http://{{ .Values.nimOperator.llm.service.name }}.{{ include "wosa.namespace" . }}.svc.cluster.local:{{ .Values.nimOperator.llm.expose.service.port }}/v1"
+              {{- else }}
+              value: {{ .Values.backend.env.llmNimUrl | quote }}
+              {{- end }}
+            - name: LLM_MODEL
+              {{- if .Values.nimOperator.llm.enabled }}
+              value: {{ trimPrefix "nvcr.io/nim/" .Values.nimOperator.llm.image.repository | quote }}
+              {{- else }}
+              value: {{ .Values.backend.env.llmModel | quote }}
+              {{- end }}
+            - name: LLM_TEMPERATURE
+              value: {{ .Values.backend.env.llmTemperature | quote }}
+            - name: LLM_MAX_TOKENS
+              value: {{ .Values.backend.env.llmMaxTokens | quote }}
+            - name: LLM_TOP_P
+              value: {{ .Values.backend.env.llmTopP | quote }}
+            - name: LLM_FREQUENCY_PENALTY
+              value: {{ .Values.backend.env.llmFrequencyPenalty | quote }}
+            - name: LLM_PRESENCE_PENALTY
+              value: {{ .Values.backend.env.llmPresencePenalty | quote }}
+            - name: LLM_CLIENT_TIMEOUT
+              value: {{ .Values.backend.env.llmClientTimeout | quote }}
+            - name: LLM_CACHE_ENABLED
+              value: {{ .Values.backend.env.llmCacheEnabled | quote }}
+            - name: LLM_CACHE_TTL_SECONDS
+              value: {{ .Values.backend.env.llmCacheTtlSeconds | quote }}
+            - name: EMBEDDING_NIM_URL
+              {{- if .Values.nimOperator.embedding.enabled }}
+              value: "http://{{ .Values.nimOperator.embedding.service.name }}.{{ include "wosa.namespace" . }}.svc.cluster.local:{{ .Values.nimOperator.embedding.expose.service.port }}/v1"
+              {{- else }}
+              value: {{ .Values.backend.env.embeddingNimUrl | quote }}
+              {{- end }}
+            - name: RAIL_API_URL
+              {{- if .Values.nimOperator.llm.enabled }}
+              value: "http://{{ .Values.nimOperator.llm.service.name }}.{{ include "wosa.namespace" . }}.svc.cluster.local:{{ .Values.nimOperator.llm.expose.service.port }}/v1"
+              {{- else }}
+              value: {{ .Values.backend.env.railApiUrl | quote }}
+              {{- end }}
+            - name: CORS_ORIGINS
+              {{- if .Values.backend.env.corsOrigins }}
+              value: {{ .Values.backend.env.corsOrigins | quote }}
+              {{- else if and .Values.openshift.enabled .Values.openshift.route.enabled .Values.openshift.route.host }}
+              value: "https://{{ .Values.openshift.route.host }}"
+              {{- else }}
+              value: ""
+              {{- end }}
+            - name: MAX_REQUEST_SIZE
+              value: {{ .Values.backend.env.maxRequestSize | quote }}
+            - name: MAX_UPLOAD_SIZE
+              value: {{ .Values.backend.env.maxUploadSize | quote }}
+            - name: MAX_PDF_PAGES_TO_PROCESS
+              value: {{ .Values.backend.env.maxPdfPagesToProcess | quote }}
+            - name: MAX_PDF_PAGES_TO_EXTRACT
+              value: {{ .Values.backend.env.maxPdfPagesToExtract | quote }}
+            - name: MILVUS_COLLECTION_NAME
+              value: {{ .Values.backend.env.milvusCollectionName | quote }}
+            - name: DEFAULT_ADMIN_PASSWORD
+              value: {{ .Values.backend.env.defaultAdminPassword | quote }}
+            # --- NeMo document processing endpoints ---
+            - name: NEMO_RETRIEVER_URL
+              value: {{ .Values.backend.env.nemoRetrieverUrl | quote }}
+            - name: NEMO_OCR_URL
+              value: {{ .Values.backend.env.nemoOcrUrl | quote }}
+            - name: NEMO_PARSE_URL
+              value: {{ .Values.backend.env.nemoParseUrl | quote }}
+            - name: LLAMA_NANO_VL_URL
+              value: {{ .Values.backend.env.llamaNanoVlUrl | quote }}
+            # --- Guardrails config ---
+            - name: GUARDRAILS_TIMEOUT
+              value: {{ .Values.backend.env.guardrailsTimeout | quote }}
+            - name: GUARDRAILS_USE_API
+              value: {{ .Values.backend.env.guardrailsUseApi | quote }}
+            - name: USE_NEMO_GUARDRAILS_SDK
+              value: {{ .Values.backend.env.useNemoGuardrailsSdk | quote }}
+            - name: GUARDRAILS_MODEL
+              value: {{ .Values.backend.env.guardrailsModel | quote }}
+            # --- Embedding & LLM Judge ---
+            - name: EMBEDDING_MODEL
+              value: {{ .Values.backend.env.embeddingModel | quote }}
+            - name: LLAMA_70B_TIMEOUT
+              value: {{ .Values.backend.env.llama70bTimeout | quote }}
+            # --- Agent/graph timeouts (override for self-hosted NIM) ---
+            {{- with .Values.backend.env.agentTimeoutSimple }}
+            - name: AGENT_TIMEOUT_SIMPLE
+              value: {{ . | quote }}
+            {{- end }}
+            {{- with .Values.backend.env.agentTimeoutComplex }}
+            - name: AGENT_TIMEOUT_COMPLEX
+              value: {{ . | quote }}
+            {{- end }}
+            {{- with .Values.backend.env.agentTimeoutReasoning }}
+            - name: AGENT_TIMEOUT_REASONING
+              value: {{ . | quote }}
+            {{- end }}
+            {{- with .Values.backend.env.graphTimeoutSimple }}
+            - name: GRAPH_TIMEOUT_SIMPLE
+              value: {{ . | quote }}
+            {{- end }}
+            {{- with .Values.backend.env.graphTimeoutComplex }}
+            - name: GRAPH_TIMEOUT_COMPLEX
+              value: {{ . | quote }}
+            {{- end }}
+            {{- with .Values.backend.env.chatTimeoutSimple }}
+            - name: CHAT_TIMEOUT_SIMPLE
+              value: {{ . | quote }}
+            {{- end }}
+            {{- with .Values.backend.env.chatTimeoutComplex }}
+            - name: CHAT_TIMEOUT_COMPLEX
+              value: {{ . | quote }}
+            {{- end }}
+            # --- Secrets ---
+            - name: NVIDIA_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "wosa.secret.name" . }}
+                  key: nvidia-api-key
+            - name: EMBEDDING_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "wosa.secret.name" . }}
+                  key: embedding-api-key
+            - name: RAIL_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "wosa.secret.name" . }}
+                  key: rail-api-key
+            - name: NEMO_RETRIEVER_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "wosa.secret.name" . }}
+                  key: nemo-retriever-api-key
+            - name: NEMO_OCR_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "wosa.secret.name" . }}
+                  key: nemo-ocr-api-key
+            - name: NEMO_PARSE_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "wosa.secret.name" . }}
+                  key: nemo-parse-api-key
+            - name: LLAMA_NANO_VL_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "wosa.secret.name" . }}
+                  key: llama-nano-vl-api-key
+            - name: JWT_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "wosa.secret.name" . }}
+                  key: jwt-secret-key
+      volumes:
+        # restricted-v2: image dirs are root-owned, random UID cannot write
+        - name: uploads
+          emptyDir: {}
+        - name: forecast-output
+          emptyDir: {}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "wosa.backend.name" . }}
+  namespace: {{ include "wosa.namespace" . }}
+  labels:
+    {{- include "wosa.labels" . | nindent 4 }}
+    app.kubernetes.io/component: backend
+spec:
+  selector:
+    {{- include "wosa.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: backend
+  ports:
+    - name: http
+      port: {{ .Values.backend.port }}
+      targetPort: http
+      protocol: TCP

--- a/deploy/helm/wosa/templates/configmaps.yaml
+++ b/deploy/helm/wosa/templates/configmaps.yaml
@@ -1,0 +1,93 @@
+{{- if .Values.nginx.enabled }}
+---
+# Nginx Configuration
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "wosa.nginx.name" . }}-config
+  namespace: {{ include "wosa.namespace" . }}
+  labels:
+    {{- include "wosa.labels" . | nindent 4 }}
+    app.kubernetes.io/component: nginx
+data:
+  nginx.conf: |
+    # PID file location writable by non-root user
+    pid /tmp/nginx.pid;
+
+    events {
+        worker_connections 1024;
+    }
+
+    http {
+        # Include MIME types for proper content-type headers
+        include /etc/nginx/mime.types;
+        default_type application/octet-stream;
+
+        client_max_body_size 10M;
+
+        # Temp file locations writable by non-root user
+        client_body_temp_path /tmp/client_temp;
+        proxy_temp_path /tmp/proxy_temp;
+        fastcgi_temp_path /tmp/fastcgi_temp;
+        uwsgi_temp_path /tmp/uwsgi_temp;
+        scgi_temp_path /tmp/scgi_temp;
+
+        upstream frontend {
+            server {{ include "wosa.frontend.name" . }}:{{ .Values.frontend.service.port }};
+        }
+
+        upstream backend {
+            server {{ include "wosa.backend.name" . }}:{{ .Values.backend.port }};
+        }
+
+        server {
+            # Use port 8080 for non-root compatibility (ports < 1024 require root)
+            listen {{ .Values.nginx.service.port }};
+
+            # Health check endpoint - returns 200 directly without proxying
+            location /health {
+                access_log off;
+                return 200 'OK';
+                add_header Content-Type text/plain;
+            }
+
+            # Backend API
+            location /api/ {
+                proxy_pass http://backend;
+                proxy_set_header Host $host;
+                proxy_set_header X-Real-IP $remote_addr;
+                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                proxy_set_header X-Forwarded-Proto $scheme;
+
+                # Disable buffering for streaming responses
+                proxy_buffering off;
+                proxy_cache off;
+                proxy_request_buffering off;
+
+                # Increase timeouts for long-running requests (LLM inference, document processing)
+                proxy_read_timeout 300s;
+                proxy_connect_timeout 300s;
+                proxy_send_timeout 300s;
+
+                # WebSocket support
+                proxy_http_version 1.1;
+                proxy_set_header Upgrade $http_upgrade;
+                proxy_set_header Connection "upgrade";
+            }
+
+            # Frontend
+            location / {
+                proxy_pass http://frontend;
+                proxy_set_header Host $host;
+                proxy_set_header X-Real-IP $remote_addr;
+                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                proxy_set_header X-Forwarded-Proto $scheme;
+
+                # WebSocket handling
+                proxy_http_version 1.1;
+                proxy_set_header Upgrade $http_upgrade;
+                proxy_set_header Connection "upgrade";
+            }
+        }
+    }
+{{- end }}

--- a/deploy/helm/wosa/templates/db-init-job.yaml
+++ b/deploy/helm/wosa/templates/db-init-job.yaml
@@ -1,0 +1,86 @@
+{{- if .Values.dbInit.enabled }}
+---
+# Job: runs SQL init scripts against TimescaleDB after install/upgrade.
+# SQL files are copied from the backend image (single source of truth).
+# All scripts use CREATE TABLE IF NOT EXISTS — safe to run on every upgrade.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "wosa.fullname" . }}-db-init
+  namespace: {{ include "wosa.namespace" . }}
+  labels:
+    {{- include "wosa.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 5
+  template:
+    metadata:
+      labels:
+        {{- include "wosa.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- include "wosa.podSecurityContext" . | nindent 6 }}
+      {{- include "wosa.imagePullSecrets" . | nindent 6 }}
+      serviceAccountName: {{ include "wosa.serviceAccountName" . }}
+      restartPolicy: OnFailure
+      initContainers:
+        - name: copy-sql
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          {{- include "wosa.containerSecurityContext" . | nindent 10 }}
+          command:
+            - sh
+            - -c
+            - |
+              cp /app/data/postgres/[0-9]*.sql /sql/
+              cp /app/scripts/setup/create_model_tracking_tables.sql /sql/
+          volumeMounts:
+            - name: sql
+              mountPath: /sql
+      containers:
+        - name: db-init
+          image: "{{ .Values.timescaledb.image.repository }}:{{ .Values.timescaledb.image.tag }}"
+          {{- include "wosa.containerSecurityContext" . | nindent 10 }}
+          command:
+            - sh
+            - -c
+            - |
+              echo "Waiting for TimescaleDB to be ready..."
+              until pg_isready -h "$DB_HOST" -p "$DB_PORT" -U "$POSTGRES_USER" -d "$POSTGRES_DB"; do
+                echo "  not ready, retrying in 5s..."
+                sleep 5
+              done
+              echo "Running init scripts..."
+              for f in $(ls /sql/*.sql | sort); do
+                echo "  Applying $f..."
+                psql -h "$DB_HOST" -p "$DB_PORT" -U "$POSTGRES_USER" -d "$POSTGRES_DB" -f "$f" || true
+              done
+              echo "DB init complete."
+          env:
+            - name: DB_HOST
+              value: {{ include "wosa.timescaledb.name" . | quote }}
+            - name: DB_PORT
+              value: {{ .Values.timescaledb.port | quote }}
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "wosa.secret.name" . }}
+                  key: postgres-user
+            - name: POSTGRES_DB
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "wosa.secret.name" . }}
+                  key: postgres-db
+            - name: PGPASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "wosa.secret.name" . }}
+                  key: postgres-password
+          volumeMounts:
+            - name: sql
+              mountPath: /sql
+      volumes:
+        - name: sql
+          emptyDir: {}
+{{- end }}

--- a/deploy/helm/wosa/templates/demo-data-job.yaml
+++ b/deploy/helm/wosa/templates/demo-data-job.yaml
@@ -1,0 +1,74 @@
+{{- if .Values.demoData.enabled }}
+---
+# Job: seeds demo inventory, tasks, incidents, telemetry, and audit log.
+# post-install only - demo data should not re-run on upgrades.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "wosa.fullname" . }}-demo-data
+  namespace: {{ include "wosa.namespace" . }}
+  labels:
+    {{- include "wosa.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": post-install
+    "helm.sh/hook-weight": "2"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 3
+  template:
+    metadata:
+      labels:
+        {{- include "wosa.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- include "wosa.podSecurityContext" . | nindent 6 }}
+      {{- include "wosa.imagePullSecrets" . | nindent 6 }}
+      serviceAccountName: {{ include "wosa.serviceAccountName" . }}
+      restartPolicy: OnFailure
+      containers:
+        - name: demo-data
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- include "wosa.containerSecurityContext" . | nindent 10 }}
+          command:
+            - sh
+            - -c
+            - |
+              echo "Waiting for TimescaleDB to be ready..."
+              until python -c "
+              import asyncio, psycopg, os
+              async def check():
+                  conn = await psycopg.AsyncConnection.connect(os.environ['DATABASE_URL'])
+                  await conn.close()
+              asyncio.run(check())
+              " 2>/dev/null; do
+                echo "  not ready, retrying in 5s..."
+                sleep 5
+              done
+              echo "Running quick_demo_data.py..."
+              python scripts/data/quick_demo_data.py
+          env:
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "wosa.secret.name" . }}
+                  key: postgres-user
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "wosa.secret.name" . }}
+                  key: postgres-password
+            - name: POSTGRES_DB
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "wosa.secret.name" . }}
+                  key: postgres-db
+            - name: DATABASE_URL
+              value: "postgresql://$(POSTGRES_USER):$(POSTGRES_PASSWORD)@{{ include "wosa.timescaledb.name" . }}:{{ .Values.timescaledb.port }}/$(POSTGRES_DB)"
+            - name: DEFAULT_USER_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "wosa.secret.name" . }}
+                  key: default-user-password
+            - name: PYTHONPATH
+              value: /app
+{{- end }}

--- a/deploy/helm/wosa/templates/demo-demand-job.yaml
+++ b/deploy/helm/wosa/templates/demo-demand-job.yaml
@@ -1,0 +1,81 @@
+{{- if .Values.demoDemand.enabled }}
+---
+# Job: seeds 180 days of historical demand data for the Forecasting page.
+# post-install only - historical data should not re-run on upgrades.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "wosa.fullname" . }}-demo-demand
+  namespace: {{ include "wosa.namespace" . }}
+  labels:
+    {{- include "wosa.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": post-install
+    "helm.sh/hook-weight": "3"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 3
+  template:
+    metadata:
+      labels:
+        {{- include "wosa.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- include "wosa.podSecurityContext" . | nindent 6 }}
+      {{- include "wosa.imagePullSecrets" . | nindent 6 }}
+      serviceAccountName: {{ include "wosa.serviceAccountName" . }}
+      restartPolicy: OnFailure
+      containers:
+        - name: demo-demand
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- include "wosa.containerSecurityContext" . | nindent 10 }}
+          command:
+            - sh
+            - -c
+            - |
+              echo "Waiting for TimescaleDB to be ready..."
+              until python -c "
+              import asyncio, asyncpg, os
+              async def check():
+                  conn = await asyncpg.connect(
+                      host=os.environ['PGHOST'], port=int(os.environ['PGPORT']),
+                      user=os.environ['POSTGRES_USER'], password=os.environ['POSTGRES_PASSWORD'],
+                      database=os.environ['POSTGRES_DB'])
+                  await conn.close()
+              asyncio.run(check())
+              " 2>/dev/null; do
+                echo "  not ready, retrying in 5s..."
+                sleep 5
+              done
+              echo "Running generate_historical_demand.py..."
+              python /app/scripts/data/generate_historical_demand.py
+          env:
+            - name: PGHOST
+              value: {{ include "wosa.timescaledb.name" . | quote }}
+            - name: PGPORT
+              value: {{ .Values.timescaledb.port | quote }}
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "wosa.secret.name" . }}
+                  key: postgres-user
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "wosa.secret.name" . }}
+                  key: postgres-password
+            - name: POSTGRES_DB
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "wosa.secret.name" . }}
+                  key: postgres-db
+            - name: PYTHONPATH
+              value: /app
+          volumeMounts:
+            - name: scratch
+              mountPath: /app/output
+          workingDir: /app/output
+      volumes:
+        - name: scratch
+          emptyDir: {}
+{{- end }}

--- a/deploy/helm/wosa/templates/etcd-deployment.yaml
+++ b/deploy/helm/wosa/templates/etcd-deployment.yaml
@@ -1,0 +1,116 @@
+{{- if .Values.etcd.enabled }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "wosa.etcd.name" . }}
+  namespace: {{ include "wosa.namespace" . }}
+  labels:
+    {{- include "wosa.labels" . | nindent 4 }}
+    app.kubernetes.io/component: etcd
+spec:
+  replicas: {{ .Values.etcd.replicas }}
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      {{- include "wosa.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: etcd
+  template:
+    metadata:
+      labels:
+        {{- include "wosa.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: etcd
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      serviceAccountName: {{ include "wosa.serviceAccountName" . }}
+      {{- include "wosa.imagePullSecrets" . | nindent 6 }}
+      {{- include "wosa.podSecurityContext" . | nindent 6 }}
+      containers:
+        - name: etcd
+          image: "{{ .Values.etcd.image.repository }}:{{ .Values.etcd.image.tag }}"
+          imagePullPolicy: {{ .Values.etcd.image.pullPolicy }}
+          ports:
+            - name: client
+              containerPort: {{ .Values.etcd.port }}
+              protocol: TCP
+          resources:
+            {{- toYaml .Values.etcd.resources | nindent 12 }}
+          {{- include "wosa.containerSecurityContext" . | nindent 10 }}
+          livenessProbe:
+            exec:
+              command: ["etcdctl", "endpoint", "health"]
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            exec:
+              command: ["etcdctl", "endpoint", "health"]
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 3
+          env:
+            - name: ETCD_DATA_DIR
+              value: /var/etcd/data
+            - name: ETCD_AUTO_COMPACTION_MODE
+              value: revision
+            - name: ETCD_AUTO_COMPACTION_RETENTION
+              value: "1000"
+            - name: ETCD_QUOTA_BACKEND_BYTES
+              value: "4294967296"
+            - name: ETCD_SNAPSHOT_COUNT
+              value: "50000"
+            - name: ETCD_HEARTBEAT_INTERVAL
+              value: "500"
+            - name: ETCD_ELECTION_TIMEOUT
+              value: "2500"
+            - name: ETCD_LISTEN_CLIENT_URLS
+              value: {{ printf "http://0.0.0.0:%v" .Values.etcd.port | quote }}
+            - name: ETCD_ADVERTISE_CLIENT_URLS
+              value: {{ printf "http://%s:%v" (include "wosa.etcd.name" .) .Values.etcd.port | quote }}
+          {{- if .Values.etcd.persistence.enabled }}
+          volumeMounts:
+            - name: data
+              mountPath: /var/etcd/data
+          {{- end }}
+      {{- if .Values.etcd.persistence.enabled }}
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: {{ include "wosa.etcd.name" . }}-data
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "wosa.etcd.name" . }}
+  namespace: {{ include "wosa.namespace" . }}
+  labels:
+    {{- include "wosa.labels" . | nindent 4 }}
+    app.kubernetes.io/component: etcd
+spec:
+  selector:
+    {{- include "wosa.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: etcd
+  ports:
+    - name: client
+      port: {{ .Values.etcd.port }}
+      targetPort: client
+      protocol: TCP
+{{- end }}

--- a/deploy/helm/wosa/templates/frontend-deployment.yaml
+++ b/deploy/helm/wosa/templates/frontend-deployment.yaml
@@ -1,0 +1,86 @@
+{{- if .Values.frontend.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "wosa.frontend.name" . }}
+  namespace: {{ include "wosa.namespace" . }}
+  labels:
+    {{- include "wosa.labels" . | nindent 4 }}
+    app.kubernetes.io/component: frontend
+spec:
+  replicas: {{ .Values.frontend.replicas }}
+  selector:
+    matchLabels:
+      {{- include "wosa.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: frontend
+  template:
+    metadata:
+      labels:
+        {{- include "wosa.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: frontend
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- include "wosa.imagePullSecrets" . | nindent 6 }}
+      serviceAccountName: {{ include "wosa.serviceAccountName" . }}
+      {{- include "wosa.podSecurityContext" . | nindent 6 }}
+      containers:
+        - name: frontend
+          image: "{{ .Values.frontend.image.repository }}:{{ .Values.frontend.image.tag }}"
+          imagePullPolicy: {{ .Values.frontend.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.frontend.service.port }}
+              protocol: TCP
+          resources:
+            {{- toYaml .Values.frontend.resources | nindent 12 }}
+          {{- include "wosa.containerSecurityContext" . | nindent 10 }}
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.frontend.healthCheck.path }}
+              port: http
+            initialDelaySeconds: {{ .Values.frontend.healthCheck.initialDelaySeconds }}
+            periodSeconds: {{ .Values.frontend.healthCheck.periodSeconds }}
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.frontend.healthCheck.path }}
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 3
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "wosa.frontend.name" . }}
+  namespace: {{ include "wosa.namespace" . }}
+  labels:
+    {{- include "wosa.labels" . | nindent 4 }}
+    app.kubernetes.io/component: frontend
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: {{ .Values.frontend.service.port }}
+      targetPort: {{ .Values.frontend.service.port }}
+      protocol: TCP
+  selector:
+    {{- include "wosa.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: frontend
+{{- end }}

--- a/deploy/helm/wosa/templates/kafka-deployment.yaml
+++ b/deploy/helm/wosa/templates/kafka-deployment.yaml
@@ -1,0 +1,133 @@
+{{- if .Values.kafka.enabled }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "wosa.kafka.name" . }}
+  namespace: {{ include "wosa.namespace" . }}
+  labels:
+    {{- include "wosa.labels" . | nindent 4 }}
+    app.kubernetes.io/component: kafka
+spec:
+  replicas: {{ .Values.kafka.replicas }}
+  selector:
+    matchLabels:
+      {{- include "wosa.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: kafka
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        {{- include "wosa.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: kafka
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      serviceAccountName: {{ include "wosa.serviceAccountName" . }}
+      {{- include "wosa.imagePullSecrets" . | nindent 6 }}
+      {{- include "wosa.podSecurityContext" . | nindent 6 }}
+      containers:
+        - name: kafka
+          image: "{{ .Values.kafka.image.repository }}:{{ .Values.kafka.image.tag }}"
+          imagePullPolicy: {{ .Values.kafka.image.pullPolicy }}
+          ports:
+            - name: client
+              containerPort: {{ .Values.kafka.port }}
+              protocol: TCP
+          resources:
+            {{- toYaml .Values.kafka.resources | nindent 12 }}
+          {{- include "wosa.containerSecurityContext" . | nindent 10 }}
+          livenessProbe:
+            tcpSocket:
+              port: client
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            tcpSocket:
+              port: client
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+          env:
+            - name: KAFKA_NODE_ID
+              value: "1"
+            - name: KAFKA_PROCESS_ROLES
+              value: broker,controller
+            - name: KAFKA_LISTENERS
+              value: {{ printf "PLAINTEXT://:%v,CONTROLLER://:9093" .Values.kafka.port | quote }}
+            - name: KAFKA_ADVERTISED_LISTENERS
+              value: {{ printf "PLAINTEXT://%s:%v" (include "wosa.kafka.name" .) .Values.kafka.port | quote }}
+            - name: KAFKA_LISTENER_SECURITY_PROTOCOL_MAP
+              value: PLAINTEXT:PLAINTEXT,CONTROLLER:PLAINTEXT
+            - name: KAFKA_CONTROLLER_QUORUM_VOTERS
+              value: "1@localhost:9093"
+            - name: KAFKA_CONTROLLER_LISTENER_NAMES
+              value: CONTROLLER
+            - name: KAFKA_INTER_BROKER_LISTENER_NAME
+              value: PLAINTEXT
+            - name: KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR
+              value: "1"
+            - name: KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR
+              value: "1"
+            - name: KAFKA_TRANSACTION_STATE_LOG_MIN_ISR
+              value: "1"
+            - name: KAFKA_LOG_DIRS
+              value: /var/lib/kafka/data/kraft-logs
+            - name: CLUSTER_ID
+              value: {{ .Values.kafka.clusterId | quote }}
+          volumeMounts:
+            {{- if .Values.kafka.persistence.enabled }}
+            - name: data
+              mountPath: /var/lib/kafka/data
+            {{- end }}
+            - name: config
+              mountPath: /opt/kafka/config
+            - name: logs
+              mountPath: /opt/kafka/logs
+      volumes:
+        {{- if .Values.kafka.persistence.enabled }}
+        - name: data
+          persistentVolumeClaim:
+            claimName: {{ include "wosa.kafka.name" . }}-data
+        {{- end }}
+        # restricted-v2: image dirs are root-owned, random UID cannot write
+        - name: config
+          emptyDir: {}
+        - name: logs
+          emptyDir: {}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "wosa.kafka.name" . }}
+  namespace: {{ include "wosa.namespace" . }}
+  labels:
+    {{- include "wosa.labels" . | nindent 4 }}
+    app.kubernetes.io/component: kafka
+spec:
+  selector:
+    {{- include "wosa.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: kafka
+  ports:
+    - name: client
+      port: {{ .Values.kafka.port }}
+      targetPort: client
+      protocol: TCP
+{{- end }}

--- a/deploy/helm/wosa/templates/milvus-deployment.yaml
+++ b/deploy/helm/wosa/templates/milvus-deployment.yaml
@@ -1,0 +1,184 @@
+{{- if .Values.milvus.enabled }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "wosa.milvus.name" . }}
+  namespace: {{ include "wosa.namespace" . }}
+  labels:
+    {{- include "wosa.labels" . | nindent 4 }}
+    app.kubernetes.io/component: milvus
+spec:
+  replicas: {{ .Values.milvus.replicas }}
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      {{- include "wosa.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: milvus
+  template:
+    metadata:
+      labels:
+        {{- include "wosa.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: milvus
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      serviceAccountName: {{ include "wosa.serviceAccountName" . }}
+      {{- include "wosa.imagePullSecrets" . | nindent 6 }}
+      {{- if or (and .Values.milvus.gpu.enabled .Values.milvus.gpu.tolerations) .Values.tolerations }}
+      tolerations:
+        {{- if .Values.tolerations }}
+        {{- toYaml .Values.tolerations | nindent 8 }}
+        {{- end }}
+        {{- if and .Values.milvus.gpu.enabled .Values.milvus.gpu.tolerations }}
+        {{- toYaml .Values.milvus.gpu.tolerations | nindent 8 }}
+        {{- end }}
+      {{- end }}
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+        fsGroupChangePolicy: OnRootMismatch
+      {{- if .Values.milvus.persistence.enabled }}
+      initContainers:
+        - name: volume-permissions
+          image: busybox:1.36
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/sh
+            - -c
+            - |
+              mkdir -p /var/lib/milvus/data
+              mkdir -p /var/lib/milvus/logs
+              mkdir -p /var/lib/milvus/wal
+              mkdir -p /var/lib/milvus/rdb_data
+              mkdir -p /var/lib/milvus/rdb_data_meta_kv
+              echo "Milvus directories created"
+              ls -la /var/lib/milvus/
+          volumeMounts:
+            - name: milvus-data
+              mountPath: /var/lib/milvus
+          {{- include "wosa.containerSecurityContext" . | nindent 10 }}
+      {{- end }}
+      containers:
+        - name: milvus
+          {{- if .Values.milvus.gpu.enabled }}
+          image: "{{ .Values.milvus.image.repository }}:{{ .Values.milvus.image.tag }}-gpu"
+          {{- else }}
+          image: "{{ .Values.milvus.image.repository }}:{{ .Values.milvus.image.tag }}"
+          {{- end }}
+          imagePullPolicy: {{ .Values.milvus.image.pullPolicy }}
+          args: ["milvus", "run", "standalone"]
+          ports:
+            - name: grpc
+              containerPort: {{ .Values.milvus.port }}
+              protocol: TCP
+            - name: http
+              containerPort: {{ .Values.milvus.httpPort }}
+              protocol: TCP
+          resources:
+            {{- if .Values.milvus.gpu.enabled }}
+            requests:
+              {{- toYaml .Values.milvus.resources.requests | nindent 14 }}
+              nvidia.com/gpu: "1"
+            limits:
+              {{- toYaml .Values.milvus.resources.limits | nindent 14 }}
+              nvidia.com/gpu: "1"
+            {{- else }}
+            {{- toYaml .Values.milvus.resources | nindent 12 }}
+            {{- end }}
+          {{- include "wosa.containerSecurityContext" . | nindent 10 }}
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 90
+            periodSeconds: 30
+            timeoutSeconds: 10
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+          env:
+            - name: ETCD_ENDPOINTS
+              value: {{ printf "%s:%v" (include "wosa.etcd.name" .) .Values.etcd.port | quote }}
+            - name: MINIO_ADDRESS
+              value: {{ printf "%s:%v" (include "wosa.minio.name" .) .Values.minio.service.apiPort | quote }}
+            - name: MINIO_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "wosa.secret.name" . }}
+                  key: minio-access-key
+            - name: MINIO_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "wosa.secret.name" . }}
+                  key: minio-secret-key
+            - name: MINIO_USE_SSL
+              value: "false"
+            - name: COMMON_STORAGETYPE
+              value: "local"
+            {{- if .Values.milvus.gpu.enabled }}
+            - name: CUDA_VISIBLE_DEVICES
+              value: {{ .Values.milvus.gpu.deviceId | quote }}
+            - name: MILVUS_USE_GPU
+              value: "true"
+            - name: MILVUS_GPU_DEVICE_ID
+              value: {{ .Values.milvus.gpu.deviceId | quote }}
+            {{- end }}
+            # Explicit path configurations for OpenShift compatibility
+            - name: MILVUS_LOG_PATH
+              value: "/var/lib/milvus/logs/milvus.log"
+            - name: ROCKSMQ_PATH
+              value: "/var/lib/milvus/rdb_data"
+            - name: COMMON_STORAGEROOTPATH
+              value: "/var/lib/milvus/data"
+          {{- if .Values.milvus.persistence.enabled }}
+          volumeMounts:
+            - name: milvus-data
+              mountPath: /var/lib/milvus
+          {{- end }}
+      {{- if .Values.milvus.persistence.enabled }}
+      volumes:
+        - name: milvus-data
+          persistentVolumeClaim:
+            claimName: {{ include "wosa.milvus.name" . }}-data
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "wosa.milvus.name" . }}
+  namespace: {{ include "wosa.namespace" . }}
+  labels:
+    {{- include "wosa.labels" . | nindent 4 }}
+    app.kubernetes.io/component: milvus
+spec:
+  selector:
+    {{- include "wosa.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: milvus
+  ports:
+    - name: grpc
+      port: {{ .Values.milvus.port }}
+      targetPort: grpc
+      protocol: TCP
+    - name: http
+      port: {{ .Values.milvus.httpPort }}
+      targetPort: http
+      protocol: TCP
+{{- end }}

--- a/deploy/helm/wosa/templates/minio-deployment.yaml
+++ b/deploy/helm/wosa/templates/minio-deployment.yaml
@@ -1,0 +1,118 @@
+{{- if .Values.minio.enabled }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "wosa.minio.name" . }}
+  namespace: {{ include "wosa.namespace" . }}
+  labels:
+    {{- include "wosa.labels" . | nindent 4 }}
+    app.kubernetes.io/component: minio
+spec:
+  replicas: {{ .Values.minio.replicas }}
+  selector:
+    matchLabels:
+      {{- include "wosa.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: minio
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        {{- include "wosa.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: minio
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      serviceAccountName: {{ include "wosa.serviceAccountName" . }}
+      {{- include "wosa.imagePullSecrets" . | nindent 6 }}
+      {{- include "wosa.podSecurityContext" . | nindent 6 }}
+      containers:
+        - name: minio
+          image: "{{ .Values.minio.image.repository }}:{{ .Values.minio.image.tag }}"
+          imagePullPolicy: {{ .Values.minio.image.pullPolicy }}
+          args: ["server", "/data", "--console-address", ":{{ .Values.minio.service.consolePort }}"]
+          ports:
+            - name: api
+              containerPort: {{ .Values.minio.service.apiPort }}
+              protocol: TCP
+            - name: console
+              containerPort: {{ .Values.minio.service.consolePort }}
+              protocol: TCP
+          resources:
+            {{- toYaml .Values.minio.resources | nindent 12 }}
+          {{- include "wosa.containerSecurityContext" . | nindent 10 }}
+          livenessProbe:
+            httpGet:
+              path: /minio/health/live
+              port: api
+            initialDelaySeconds: 20
+            periodSeconds: 30
+            timeoutSeconds: 3
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /minio/health/ready
+              port: api
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 3
+          env:
+            - name: MINIO_ROOT_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "wosa.secret.name" . }}
+                  key: minio-access-key
+            - name: MINIO_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "wosa.secret.name" . }}
+                  key: minio-secret-key
+          {{- if .Values.minio.persistence.enabled }}
+          volumeMounts:
+            - name: data
+              mountPath: /data
+          {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.minio.persistence.enabled }}
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: {{ include "wosa.minio.name" . }}-data
+      {{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "wosa.minio.name" . }}
+  namespace: {{ include "wosa.namespace" . }}
+  labels:
+    {{- include "wosa.labels" . | nindent 4 }}
+    app.kubernetes.io/component: minio
+spec:
+  selector:
+    {{- include "wosa.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: minio
+  ports:
+    - name: api
+      port: {{ .Values.minio.service.apiPort }}
+      targetPort: api
+      protocol: TCP
+    - name: console
+      port: {{ .Values.minio.service.consolePort }}
+      targetPort: console
+      protocol: TCP
+{{- end }}

--- a/deploy/helm/wosa/templates/monitoring-alertmanagerconfig.yaml
+++ b/deploy/helm/wosa/templates/monitoring-alertmanagerconfig.yaml
@@ -1,0 +1,73 @@
+{{- if and .Values.monitoring.enabled .Values.monitoring.alertmanager.enabled }}
+---
+apiVersion: monitoring.coreos.com/v1alpha1
+kind: AlertmanagerConfig
+metadata:
+  name: {{ include "wosa.fullname" . }}
+  namespace: {{ include "wosa.namespace" . }}
+  labels:
+    {{- include "wosa.labels" . | nindent 4 }}
+    app.kubernetes.io/component: monitoring
+spec:
+  route:
+    groupBy:
+      - alertname
+    groupWait: {{ .Values.monitoring.alertmanager.groupWait }}
+    groupInterval: {{ .Values.monitoring.alertmanager.groupInterval }}
+    repeatInterval: {{ .Values.monitoring.alertmanager.repeatInterval }}
+    receiver: web-hook
+    routes:
+      - matchers:
+          - name: severity
+            value: critical
+        receiver: critical-alerts
+      - matchers:
+          - name: severity
+            value: warning
+        receiver: warning-alerts
+  receivers:
+    - name: web-hook
+      webhookConfigs:
+        - url: {{ .Values.monitoring.alertmanager.receivers.default.webhookUrl | quote }}
+    - name: critical-alerts
+      emailConfigs:
+        - to: {{ .Values.monitoring.alertmanager.receivers.critical.email | quote }}
+          from: {{ .Values.monitoring.alertmanager.smtp.from | quote }}
+          smarthost: {{ .Values.monitoring.alertmanager.smtp.smarthost | quote }}
+          headers:
+            - key: Subject
+              value: {{ .Values.monitoring.alertmanager.receivers.critical.subject | quote }}
+          text: |
+            {{ "{{ range .Alerts }}" }}
+            Alert: {{ "{{ .Annotations.summary }}" }}
+            Description: {{ "{{ .Annotations.description }}" }}
+            {{ "{{ end }}" }}
+      webhookConfigs:
+        - url: {{ .Values.monitoring.alertmanager.receivers.critical.webhookUrl | quote }}
+    - name: warning-alerts
+      emailConfigs:
+        - to: {{ .Values.monitoring.alertmanager.receivers.warning.email | quote }}
+          from: {{ .Values.monitoring.alertmanager.smtp.from | quote }}
+          smarthost: {{ .Values.monitoring.alertmanager.smtp.smarthost | quote }}
+          headers:
+            - key: Subject
+              value: {{ .Values.monitoring.alertmanager.receivers.warning.subject | quote }}
+          text: |
+            {{ "{{ range .Alerts }}" }}
+            Alert: {{ "{{ .Annotations.summary }}" }}
+            Description: {{ "{{ .Annotations.description }}" }}
+            {{ "{{ end }}" }}
+      webhookConfigs:
+        - url: {{ .Values.monitoring.alertmanager.receivers.warning.webhookUrl | quote }}
+  inhibitRules:
+    - sourceMatch:
+        - name: severity
+          value: critical
+      targetMatch:
+        - name: severity
+          value: warning
+      equal:
+        - alertname
+        - dev
+        - instance
+{{- end }}

--- a/deploy/helm/wosa/templates/monitoring-dashboards.yaml
+++ b/deploy/helm/wosa/templates/monitoring-dashboards.yaml
@@ -1,0 +1,27 @@
+{{- if and .Values.monitoring.enabled .Values.monitoring.grafana.enabled .Values.monitoring.grafana.dashboards.enabled }}
+{{- range $path, $_ := .Files.Glob "dashboards/*.json" }}
+{{- $rawJson := $.Files.Get $path }}
+{{- $name := trimSuffix ".json" (base $path) }}
+{{- $parsed := fromJson $rawJson -}}
+{{- $dashboard := $parsed -}}
+{{- if hasKey $parsed "dashboard" -}}
+{{-   $dashboard = $parsed.dashboard -}}
+{{- end }}
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: {{ include "wosa.fullname" $ }}-{{ $name }}
+  namespace: {{ include "wosa.namespace" $ }}
+  labels:
+    {{- include "wosa.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: monitoring
+spec:
+  resyncPeriod: 5m
+  instanceSelector:
+    matchLabels:
+      dashboards: {{ include "wosa.fullname" $ }}
+  json: |
+    {{ toJson $dashboard | nindent 4 }}
+{{ end }}
+{{- end }}

--- a/deploy/helm/wosa/templates/monitoring-grafana.yaml
+++ b/deploy/helm/wosa/templates/monitoring-grafana.yaml
@@ -1,0 +1,148 @@
+{{- if and .Values.monitoring.enabled .Values.monitoring.grafana.enabled }}
+
+# OperatorGroup - set monitoring.grafana.createOperatorGroup=false if one already exists.
+{{- if not (eq (.Values.monitoring.grafana.createOperatorGroup | toString) "false") }}
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: {{ include "wosa.fullname" . }}-grafana-og
+  namespace: {{ include "wosa.namespace" . }}
+  labels:
+    {{- include "wosa.labels" . | nindent 4 }}
+    app.kubernetes.io/component: monitoring
+spec:
+  targetNamespaces:
+    - {{ include "wosa.namespace" . }}
+{{- end }}
+
+# OLM Subscription
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: grafana-operator
+  namespace: {{ include "wosa.namespace" . }}
+  labels:
+    {{- include "wosa.labels" . | nindent 4 }}
+    app.kubernetes.io/component: monitoring
+spec:
+  channel: {{ .Values.monitoring.grafana.channel }}
+  installPlanApproval: Automatic
+  name: grafana-operator
+  source: {{ .Values.monitoring.grafana.catalogSource }}
+  sourceNamespace: {{ .Values.monitoring.grafana.catalogSourceNamespace }}
+
+# Grafana ServiceAccount
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "wosa.fullname" . }}-grafana
+  namespace: {{ include "wosa.namespace" . }}
+  labels:
+    {{- include "wosa.labels" . | nindent 4 }}
+    app.kubernetes.io/component: monitoring
+
+# ClusterRoleBinding - cluster-monitoring-view access
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "wosa.fullname" . }}-{{ include "wosa.namespace" . }}-grafana-monitoring-view
+  labels:
+    {{- include "wosa.labels" . | nindent 4 }}
+    app.kubernetes.io/component: monitoring
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-monitoring-view
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "wosa.fullname" . }}-grafana
+    namespace: {{ include "wosa.namespace" . }}
+
+# Grafana instance
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: Grafana
+metadata:
+  name: {{ include "wosa.fullname" . }}-grafana
+  namespace: {{ include "wosa.namespace" . }}
+  labels:
+    {{- include "wosa.labels" . | nindent 4 }}
+    app.kubernetes.io/component: monitoring
+    dashboards: {{ include "wosa.fullname" . }}
+spec:
+  deployment:
+    spec:
+      replicas: {{ .Values.monitoring.grafana.replicas }}
+      template:
+        spec:
+          containers:
+            - name: grafana
+              resources:
+                {{- toYaml .Values.monitoring.grafana.resources | nindent 16 }}
+  route:
+    spec:
+      tls:
+        termination: edge
+        insecureEdgeTerminationPolicy: Redirect
+  config:
+    log:
+      mode: "console"
+    auth.anonymous:
+      enabled: "false"
+    security:
+      admin_user: admin
+      admin_password: {{ .Values.monitoring.grafana.adminPassword | default "changeme" | quote }}
+    users:
+      allow_sign_up: "false"
+
+# GrafanaDatasource - Thanos Querier
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDatasource
+metadata:
+  name: {{ include "wosa.fullname" . }}-prometheus
+  namespace: {{ include "wosa.namespace" . }}
+  labels:
+    {{- include "wosa.labels" . | nindent 4 }}
+    app.kubernetes.io/component: monitoring
+spec:
+  instanceSelector:
+    matchLabels:
+      dashboards: {{ include "wosa.fullname" . }}
+  datasource:
+    name: Prometheus
+    type: prometheus
+    access: proxy
+    url: {{ .Values.monitoring.grafana.datasource.url }}
+    isDefault: true
+    jsonData:
+      httpHeaderName1: Authorization
+      timeInterval: "5s"
+      tlsSkipVerify: true
+    secureJsonData:
+      httpHeaderValue1: "Bearer ${token}"
+  valuesFrom:
+    - targetPath: secureJsonData.httpHeaderValue1
+      valueFrom:
+        secretKeyRef:
+          name: {{ include "wosa.fullname" . }}-grafana-sa-token
+          key: token
+
+# SA token Secret
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "wosa.fullname" . }}-grafana-sa-token
+  namespace: {{ include "wosa.namespace" . }}
+  labels:
+    {{- include "wosa.labels" . | nindent 4 }}
+    app.kubernetes.io/component: monitoring
+  annotations:
+    kubernetes.io/service-account.name: {{ include "wosa.fullname" . }}-grafana
+type: kubernetes.io/service-account-token
+{{- end }}

--- a/deploy/helm/wosa/templates/monitoring-prometheusrule.yaml
+++ b/deploy/helm/wosa/templates/monitoring-prometheusrule.yaml
@@ -1,0 +1,153 @@
+{{- if and .Values.monitoring.enabled .Values.monitoring.prometheusRules.enabled }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ include "wosa.fullname" . }}-alerts
+  namespace: {{ include "wosa.namespace" . }}
+  labels:
+    {{- include "wosa.labels" . | nindent 4 }}
+    app.kubernetes.io/component: monitoring
+spec:
+  groups:
+    - name: warehouse-operational-assistant
+      rules:
+        # API Health Checks
+        - alert: APIDown
+          expr: up{namespace="{{ include "wosa.namespace" . }}",job="warehouse-api"} == 0
+          for: 1m
+          labels:
+            severity: critical
+          annotations:
+            summary: "Warehouse API is down"
+            description: "Warehouse Operational Assistant API has been down for more than 1 minute."
+
+        - alert: APIHighErrorRate
+          expr: rate(http_requests_total{namespace="{{ include "wosa.namespace" . }}",job="warehouse-api",status=~"5.."}[5m]) > 0.1
+          for: 2m
+          labels:
+            severity: warning
+          annotations:
+            summary: "High API error rate"
+            description: "API error rate is {{ "{{ $value }}" }} errors per second."
+
+        - alert: APIHighLatency
+          expr: histogram_quantile(0.95, rate(http_request_duration_seconds_bucket{namespace="{{ include "wosa.namespace" . }}",job="warehouse-api"}[5m])) > 2
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: "High API latency"
+            description: "95th percentile latency is {{ "{{ $value }}" }} seconds."
+
+        # Database Health Checks
+        - alert: DatabaseDown
+          expr: up{namespace="{{ include "wosa.namespace" . }}",job="postgres"} == 0
+          for: 1m
+          labels:
+            severity: critical
+          annotations:
+            summary: "PostgreSQL database is down"
+            description: "PostgreSQL database has been down for more than 1 minute."
+
+        - alert: DatabaseHighConnections
+          expr: pg_stat_database_numbackends{namespace="{{ include "wosa.namespace" . }}"} / pg_settings_max_connections{namespace="{{ include "wosa.namespace" . }}"} > 0.8
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: "High database connection usage"
+            description: "Database connection usage is {{ "{{ $value | humanizePercentage }}" }}."
+
+        # Redis Health Checks
+        - alert: RedisDown
+          expr: up{namespace="{{ include "wosa.namespace" . }}",job="redis"} == 0
+          for: 1m
+          labels:
+            severity: critical
+          annotations:
+            summary: "Redis is down"
+            description: "Redis cache has been down for more than 1 minute."
+
+        - alert: RedisHighMemoryUsage
+          expr: redis_memory_used_bytes{namespace="{{ include "wosa.namespace" . }}"} / redis_memory_max_bytes{namespace="{{ include "wosa.namespace" . }}"} > 0.9
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: "High Redis memory usage"
+            description: "Redis memory usage is {{ "{{ $value | humanizePercentage }}" }}."
+
+        # Milvus Health Checks
+        - alert: MilvusDown
+          expr: up{namespace="{{ include "wosa.namespace" . }}",job="milvus"} == 0
+          for: 1m
+          labels:
+            severity: critical
+          annotations:
+            summary: "Milvus vector database is down"
+            description: "Milvus vector database has been down for more than 1 minute."
+
+        # System Resource Alerts (pod-level - scoped to WOSA namespace)
+        # Replaces node_cpu/node_memory/node_filesystem from the original
+        # docker-compose monitoring. On OpenShift, node-level alerts are
+        # handled by platform monitoring. These use process_* metrics
+        # exposed by prometheus_client and the exporter sidecars.
+        - alert: HighCPUUsage
+          expr: rate(process_cpu_seconds_total{namespace="{{ include "wosa.namespace" . }}"}[5m]) > 0.8
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: "High CPU usage"
+            description: "Process CPU usage is {{ "{{ $value }}" }} cores in {{ "{{ $labels.job }}" }}."
+
+        - alert: HighMemoryUsage
+          expr: process_resident_memory_bytes{namespace="{{ include "wosa.namespace" . }}"} / 1024 / 1024 / 1024 > {{ .Values.monitoring.alerts.highMemoryThresholdGiB | default 3.2 }}
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: "High memory usage"
+            description: "Process memory is {{ "{{ $value }}" }} GiB in {{ "{{ $labels.job }}" }}."
+
+        # DiskSpaceLow - uses pg_database_size_bytes from postgres-exporter.
+        # kubelet_volume_stats is platform-only (not available in user workload monitoring).
+        # This fires when the database exceeds 8 GiB (80% of the default 10Gi PVC).
+        - alert: DiskSpaceLow
+          expr: pg_database_size_bytes{namespace="{{ include "wosa.namespace" . }}"} > 8589934592
+          for: 5m
+          labels:
+            severity: critical
+          annotations:
+            summary: "Database disk usage high"
+            description: "Database {{ "{{ $labels.datname }}" }} size is {{ "{{ $value | humanize1024 }}" }}B, approaching PVC capacity."
+
+        # Business Logic Alerts
+        - alert: HighInventoryAlerts
+          expr: increase(warehouse_inventory_alerts_total{namespace="{{ include "wosa.namespace" . }}"}[1h]) > 10
+          for: 0m
+          labels:
+            severity: warning
+          annotations:
+            summary: "High number of inventory alerts"
+            description: "{{ "{{ $value }}" }} inventory alerts in the last hour."
+
+        - alert: SafetyIncidentDetected
+          expr: increase(warehouse_safety_incidents_total{namespace="{{ include "wosa.namespace" . }}"}[1h]) > 0
+          for: 0m
+          labels:
+            severity: critical
+          annotations:
+            summary: "Safety incident detected"
+            description: "{{ "{{ $value }}" }} safety incidents in the last hour."
+
+        - alert: LowTaskCompletionRate
+          expr: rate(warehouse_tasks_completed_total{namespace="{{ include "wosa.namespace" . }}"}[1h]) / rate(warehouse_tasks_created_total{namespace="{{ include "wosa.namespace" . }}"}[1h]) < 0.8
+          for: 10m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Low task completion rate"
+            description: "Task completion rate is {{ "{{ $value | humanizePercentage }}" }}."
+{{- end }}

--- a/deploy/helm/wosa/templates/monitoring-servicemonitor.yaml
+++ b/deploy/helm/wosa/templates/monitoring-servicemonitor.yaml
@@ -1,0 +1,108 @@
+{{- if .Values.monitoring.enabled }}
+# Backend
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "wosa.backend.name" . }}
+  namespace: {{ include "wosa.namespace" . }}
+  labels:
+    {{- include "wosa.labels" . | nindent 4 }}
+    app.kubernetes.io/component: monitoring
+spec:
+  selector:
+    matchLabels:
+      {{- include "wosa.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: backend
+  endpoints:
+    - port: http
+      path: {{ .Values.monitoring.serviceMonitor.metricsPath }}
+      interval: {{ .Values.monitoring.serviceMonitor.interval }}
+      scrapeTimeout: {{ .Values.monitoring.serviceMonitor.scrapeTimeout }}
+      scheme: http
+      relabelings:
+        - targetLabel: job
+          replacement: warehouse-api
+      metricRelabelings:
+        - sourceLabels: [exported_endpoint]
+          regex: (.+)
+          targetLabel: endpoint
+          action: replace
+        - action: labeldrop
+          regex: exported_endpoint
+
+# TimescaleDB
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "wosa.timescaledb.name" . }}
+  namespace: {{ include "wosa.namespace" . }}
+  labels:
+    {{- include "wosa.labels" . | nindent 4 }}
+    app.kubernetes.io/component: monitoring
+spec:
+  selector:
+    matchLabels:
+      {{- include "wosa.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: timescaledb
+  endpoints:
+    - port: metrics
+      path: /metrics
+      interval: 30s
+      scrapeTimeout: 10s
+      scheme: http
+      relabelings:
+        - targetLabel: job
+          replacement: postgres
+
+# Redis
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "wosa.redis.name" . }}
+  namespace: {{ include "wosa.namespace" . }}
+  labels:
+    {{- include "wosa.labels" . | nindent 4 }}
+    app.kubernetes.io/component: monitoring
+spec:
+  selector:
+    matchLabels:
+      {{- include "wosa.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: redis
+  endpoints:
+    - port: metrics
+      path: /metrics
+      interval: 30s
+      scrapeTimeout: 10s
+      scheme: http
+      relabelings:
+        - targetLabel: job
+          replacement: redis
+
+# Milvus
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "wosa.milvus.name" . }}
+  namespace: {{ include "wosa.namespace" . }}
+  labels:
+    {{- include "wosa.labels" . | nindent 4 }}
+    app.kubernetes.io/component: monitoring
+spec:
+  selector:
+    matchLabels:
+      {{- include "wosa.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: milvus
+  endpoints:
+    - port: http
+      path: /metrics
+      interval: 30s
+      scrapeTimeout: 10s
+      scheme: http
+      relabelings:
+        - targetLabel: job
+          replacement: milvus
+{{- end }}

--- a/deploy/helm/wosa/templates/networkpolicy.yaml
+++ b/deploy/helm/wosa/templates/networkpolicy.yaml
@@ -1,0 +1,141 @@
+{{- if .Values.networkPolicy.enabled }}
+# ---------------------------------------------------------------------------
+# Policy 1: Default deny - block all ingress to WOSA pods
+# ---------------------------------------------------------------------------
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "wosa.fullname" . }}-default-deny
+  namespace: {{ include "wosa.namespace" . }}
+  labels:
+    {{- include "wosa.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "wosa.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+{{- if .Values.openshift.enabled }}
+---
+# ---------------------------------------------------------------------------
+# Policy 2: Allow ingress from OpenShift router to nginx
+# ---------------------------------------------------------------------------
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "wosa.fullname" . }}-allow-router
+  namespace: {{ include "wosa.namespace" . }}
+  labels:
+    {{- include "wosa.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "wosa.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: nginx
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network.openshift.io/policy-group: ingress
+      ports:
+        - protocol: TCP
+          port: {{ .Values.nginx.service.port }}
+{{- end }}
+---
+# ---------------------------------------------------------------------------
+# Policy 3: Allow internal pod-to-pod + DNS + external HTTPS
+# ---------------------------------------------------------------------------
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "wosa.fullname" . }}-allow-internal
+  namespace: {{ include "wosa.namespace" . }}
+  labels:
+    {{- include "wosa.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "wosa.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              {{- include "wosa.selectorLabels" . | nindent 14 }}
+  egress:
+    # Allow DNS resolution (CoreDNS)
+    - ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+        - port: 5353
+          protocol: UDP
+        - port: 5353
+          protocol: TCP
+    - to:
+        - podSelector:
+            matchLabels:
+              {{- include "wosa.selectorLabels" . | nindent 14 }}
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/managed-by: k8s-nim-operator
+    # Allow external HTTPS (port 443) for NVIDIA cloud API calls
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+      ports:
+        - protocol: TCP
+          port: 443
+{{- if .Values.monitoring.enabled }}
+---
+# ---------------------------------------------------------------------------
+# Policy 4: Allow Prometheus scrapes + Grafana -> Thanos Querier
+# ---------------------------------------------------------------------------
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "wosa.fullname" . }}-allow-monitoring
+  namespace: {{ include "wosa.namespace" . }}
+  labels:
+    {{- include "wosa.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "wosa.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    # Allow Prometheus (openshift-monitoring) to scrape metrics endpoints
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-monitoring
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-user-workload-monitoring
+      ports:
+        - protocol: TCP
+          port: {{ .Values.backend.port }}
+        - protocol: TCP
+          port: 9187
+        - protocol: TCP
+          port: 9121
+        - protocol: TCP
+          port: {{ .Values.milvus.httpPort }}
+  egress:
+    # Allow Grafana to reach Thanos Querier in openshift-monitoring
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-monitoring
+      ports:
+        - protocol: TCP
+          port: 9091
+{{- end }}
+{{- end }}

--- a/deploy/helm/wosa/templates/nginx-deployment.yaml
+++ b/deploy/helm/wosa/templates/nginx-deployment.yaml
@@ -1,0 +1,109 @@
+{{- if .Values.nginx.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "wosa.nginx.name" . }}
+  namespace: {{ include "wosa.namespace" . }}
+  labels:
+    {{- include "wosa.labels" . | nindent 4 }}
+    app.kubernetes.io/component: nginx
+spec:
+  replicas: {{ .Values.nginx.replicas }}
+  selector:
+    matchLabels:
+      {{- include "wosa.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: nginx
+  template:
+    metadata:
+      labels:
+        {{- include "wosa.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: nginx
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- include "wosa.imagePullSecrets" . | nindent 6 }}
+      serviceAccountName: {{ include "wosa.serviceAccountName" . }}
+      {{- include "wosa.podSecurityContext" . | nindent 6 }}
+      containers:
+        - name: nginx
+          image: "{{ .Values.nginx.image.repository }}:{{ .Values.nginx.image.tag }}"
+          imagePullPolicy: {{ .Values.nginx.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.nginx.service.port }}
+              protocol: TCP
+          volumeMounts:
+            - name: nginx-config
+              mountPath: /etc/nginx/nginx.conf
+              subPath: nginx.conf
+              readOnly: true
+            # Writable directories for nginx temp files and cache
+            - name: nginx-cache
+              mountPath: /var/cache/nginx
+            - name: nginx-run
+              mountPath: /var/run
+            - name: nginx-tmp
+              mountPath: /tmp
+          resources:
+            {{- toYaml .Values.nginx.resources | nindent 12 }}
+          {{- include "wosa.containerSecurityContext" . | nindent 10 }}
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 3
+      volumes:
+        - name: nginx-config
+          configMap:
+            name: {{ include "wosa.nginx.name" . }}-config
+        # restricted-v2: image dirs are root-owned, random UID cannot write
+        - name: nginx-cache
+          emptyDir: {}
+        - name: nginx-run
+          emptyDir: {}
+        - name: nginx-tmp
+          emptyDir: {}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "wosa.nginx.name" . }}
+  namespace: {{ include "wosa.namespace" . }}
+  labels:
+    {{- include "wosa.labels" . | nindent 4 }}
+    app.kubernetes.io/component: nginx
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: {{ .Values.nginx.service.port }}
+      targetPort: {{ .Values.nginx.service.port }}
+      protocol: TCP
+  selector:
+    {{- include "wosa.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: nginx
+{{- end }}

--- a/deploy/helm/wosa/templates/nim-embedding.yaml
+++ b/deploy/helm/wosa/templates/nim-embedding.yaml
@@ -1,0 +1,66 @@
+{{- $nim := .Values.nimOperator.embedding -}}
+{{- if and (.Capabilities.APIVersions.Has "apps.nvidia.com/v1alpha1") (eq $nim.enabled true) }}
+apiVersion: apps.nvidia.com/v1alpha1
+kind: NIMCache
+metadata:
+  name: {{ $nim.service.name }}-cache
+  annotations:
+    helm.sh/resource-policy: keep
+spec:
+  source:
+    ngc:
+      modelPuller: "{{ $nim.image.repository }}:{{ $nim.image.tag }}"
+      pullSecret: {{ .Values.openshift.ngcSecret.name }}
+      authSecret: {{ .Values.openshift.ngcSecret.apiName }}
+  storage:
+    pvc:
+      create: {{ $nim.storage.pvc.create | default true }}
+      {{- if $nim.storage.pvc.storageClass }}
+      storageClass: {{ $nim.storage.pvc.storageClass }}
+      {{- end }}
+      size: {{ $nim.storage.pvc.size | default "50Gi" }}
+      volumeAccessMode: {{ $nim.storage.pvc.volumeAccessMode | default "ReadWriteOnce" }}
+  {{- with $nim.tolerations }}
+  tolerations:
+{{ toYaml . | nindent 4 }}
+  {{- end }}
+---
+apiVersion: apps.nvidia.com/v1alpha1
+kind: NIMService
+metadata:
+  name: {{ $nim.service.name }}
+spec:
+  image:
+    repository: {{ $nim.image.repository }}
+    tag: "{{ $nim.image.tag }}"
+    pullPolicy: {{ $nim.image.pullPolicy | default "Always" }}
+    pullSecrets:
+      - {{ .Values.openshift.ngcSecret.name }}
+  authSecret: {{ .Values.openshift.ngcSecret.apiName }}
+  storage:
+    nimCache:
+      name: {{ $nim.service.name }}-cache
+  replicas: {{ $nim.replicas | default 1 }}
+  resources:
+{{ toYaml $nim.resources | nindent 4 }}
+  expose:
+{{ toYaml $nim.expose | nindent 4 }}
+  env:
+{{ toYaml $nim.env | nindent 4 }}
+  {{- with $nim.startupProbe }}
+  {{- if .enabled }}
+  startupProbe:
+    enabled: true
+    probe:
+{{ toYaml .probe | nindent 6 }}
+  {{- end }}
+  {{- end }}
+  {{- with $nim.tolerations }}
+  tolerations:
+{{ toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with $nim.nodeSelector }}
+  nodeSelector:
+{{ toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/deploy/helm/wosa/templates/nim-llm.yaml
+++ b/deploy/helm/wosa/templates/nim-llm.yaml
@@ -1,0 +1,78 @@
+{{- $nim := .Values.nimOperator.llm -}}
+{{- if and (.Capabilities.APIVersions.Has "apps.nvidia.com/v1alpha1") (eq $nim.enabled true) }}
+apiVersion: apps.nvidia.com/v1alpha1
+kind: NIMCache
+metadata:
+  name: {{ $nim.service.name }}-cache
+  annotations:
+    helm.sh/resource-policy: keep
+spec:
+  source:
+    ngc:
+      modelPuller: "{{ $nim.image.repository }}:{{ $nim.image.tag }}"
+      pullSecret: {{ .Values.openshift.ngcSecret.name }}
+      authSecret: {{ .Values.openshift.ngcSecret.apiName }}
+      {{- if or $nim.model.precision $nim.model.tensorParallelism }}
+      model:
+        {{- if $nim.model.precision }}
+        precision: "{{ $nim.model.precision }}"
+        {{- end }}
+        {{- if $nim.model.tensorParallelism }}
+        tensorParallelism: "{{ $nim.model.tensorParallelism }}"
+        {{- end }}
+      {{- end }}
+  storage:
+    pvc:
+      create: {{ $nim.storage.pvc.create | default true }}
+      {{- if $nim.storage.pvc.storageClass }}
+      storageClass: {{ $nim.storage.pvc.storageClass }}
+      {{- end }}
+      size: {{ $nim.storage.pvc.size | default "100Gi" }}
+      volumeAccessMode: {{ $nim.storage.pvc.volumeAccessMode | default "ReadWriteOnce" }}
+  {{- with $nim.tolerations }}
+  tolerations:
+{{ toYaml . | nindent 4 }}
+  {{- end }}
+---
+apiVersion: apps.nvidia.com/v1alpha1
+kind: NIMService
+metadata:
+  name: {{ $nim.service.name }}
+spec:
+  image:
+    repository: {{ $nim.image.repository }}
+    tag: "{{ $nim.image.tag }}"
+    pullPolicy: {{ $nim.image.pullPolicy | default "Always" }}
+    pullSecrets:
+      - {{ .Values.openshift.ngcSecret.name }}
+  authSecret: {{ .Values.openshift.ngcSecret.apiName }}
+  storage:
+    nimCache:
+      name: {{ $nim.service.name }}-cache
+      {{- if $nim.model.profile }}
+      profile: {{ $nim.model.profile | quote }}
+      {{- end }}
+  replicas: {{ $nim.replicas | default 1 }}
+  resources:
+{{ toYaml $nim.resources | nindent 4 }}
+  expose:
+{{ toYaml $nim.expose | nindent 4 }}
+  env:
+{{ toYaml $nim.env | nindent 4 }}
+  {{- with $nim.startupProbe }}
+  {{- if .enabled }}
+  startupProbe:
+    enabled: true
+    probe:
+{{ toYaml .probe | nindent 6 }}
+  {{- end }}
+  {{- end }}
+  {{- with $nim.tolerations }}
+  tolerations:
+{{ toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with $nim.nodeSelector }}
+  nodeSelector:
+{{ toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/deploy/helm/wosa/templates/openshift-route.yaml
+++ b/deploy/helm/wosa/templates/openshift-route.yaml
@@ -1,0 +1,31 @@
+{{- if and .Values.openshift.enabled .Values.openshift.route.enabled }}
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ include "wosa.fullname" . }}
+  namespace: {{ include "wosa.namespace" . }}
+  labels:
+    {{- include "wosa.labels" . | nindent 4 }}
+    app.kubernetes.io/component: nginx
+  annotations:
+    haproxy.router.openshift.io/timeout: {{ .Values.openshift.route.timeout | quote }}
+    {{- with .Values.openshift.route.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  {{- if .Values.openshift.route.host }}
+  host: {{ .Values.openshift.route.host | quote }}
+  {{- end }}
+  to:
+    kind: Service
+    name: {{ include "wosa.nginx.name" . }}
+    weight: 100
+  port:
+    targetPort: http
+  tls:
+    termination: {{ .Values.openshift.route.tls.termination }}
+    {{- if ne .Values.openshift.route.tls.termination "passthrough" }}
+    insecureEdgeTerminationPolicy: {{ .Values.openshift.route.tls.insecureEdgeTerminationPolicy }}
+    {{- end }}
+  wildcardPolicy: None
+{{- end }}

--- a/deploy/helm/wosa/templates/openshift-scc.yaml
+++ b/deploy/helm/wosa/templates/openshift-scc.yaml
@@ -1,0 +1,89 @@
+{{- if and .Values.openshift.enabled .Values.openshift.scc.create }}
+
+# Custom SCC: allows runAsUser for NIM pods and skips recursive SELinux
+# relabeling on NIM model PVCs.
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  name: {{ .Release.Name }}-nim
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  annotations:
+    kubernetes.io/description: >-
+      Custom SCC for WOSA pods. Allows containers to run as the UID defined
+      in their images and skips recursive SELinux relabeling on volume mounts.
+priority: {{ .Values.openshift.scc.priority }}
+allowHostDirVolumePlugin: false
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: false
+allowHostPorts: false
+allowPrivilegeEscalation: true
+allowPrivilegedContainer: false
+allowedCapabilities: null
+defaultAddCapabilities: null
+fsGroup:
+  type: RunAsAny
+readOnlyRootFilesystem: false
+requiredDropCapabilities:
+  - KILL
+  - MKNOD
+  - SETUID
+  - SETGID
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: RunAsAny
+supplementalGroups:
+  type: RunAsAny
+users:
+  - system:serviceaccount:{{ .Release.Namespace }}:default
+  - system:serviceaccount:{{ .Release.Namespace }}:{{ include "wosa.serviceAccountName" . }}
+  - system:serviceaccount:{{ .Release.Namespace }}:nim-cache-sa
+  {{- range $nimKey, $nimVal := .Values.nimOperator }}
+  {{- if and (kindIs "map" $nimVal) (hasKey $nimVal "service") }}
+  - system:serviceaccount:{{ $.Release.Namespace }}:{{ $nimVal.service.name }}
+  {{- end }}
+  {{- end }}
+volumes:
+  - configMap
+  - csi
+  - downwardAPI
+  - emptyDir
+  - ephemeral
+  - persistentVolumeClaim
+  - projected
+  - secret
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ .Release.Name }}-nim-scc
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:openshift:scc:{{ .Release.Name }}-nim
+subjects:
+  - kind: ServiceAccount
+    name: default
+    namespace: {{ .Release.Namespace }}
+  - kind: ServiceAccount
+    name: {{ include "wosa.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+  - kind: ServiceAccount
+    name: nim-cache-sa
+    namespace: {{ .Release.Namespace }}
+  {{- range $nimKey, $nimVal := .Values.nimOperator }}
+  {{- if and (kindIs "map" $nimVal) (hasKey $nimVal "service") }}
+  - kind: ServiceAccount
+    name: {{ $nimVal.service.name }}
+    namespace: {{ $.Release.Namespace }}
+  {{- end }}
+  {{- end }}
+
+{{- end }}

--- a/deploy/helm/wosa/templates/pvcs.yaml
+++ b/deploy/helm/wosa/templates/pvcs.yaml
@@ -1,0 +1,114 @@
+{{/* TimescaleDB Data PVC */}}
+{{- if and .Values.timescaledb.enabled .Values.timescaledb.persistence.enabled }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "wosa.timescaledb.name" . }}-data
+  namespace: {{ include "wosa.namespace" . }}
+  labels:
+    {{- include "wosa.labels" . | nindent 4 }}
+    app.kubernetes.io/component: timescaledb
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .Values.timescaledb.persistence.size }}
+  {{- include "wosa.storageClass" . | nindent 2 }}
+{{- end }}
+{{/* Redis Data PVC */}}
+{{- if and .Values.redis.enabled .Values.redis.persistence.enabled }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "wosa.redis.name" . }}-data
+  namespace: {{ include "wosa.namespace" . }}
+  labels:
+    {{- include "wosa.labels" . | nindent 4 }}
+    app.kubernetes.io/component: redis
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .Values.redis.persistence.size }}
+  {{- include "wosa.storageClass" . | nindent 2 }}
+{{- end }}
+{{/* Kafka Data PVC */}}
+{{- if and .Values.kafka.enabled .Values.kafka.persistence.enabled }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "wosa.kafka.name" . }}-data
+  namespace: {{ include "wosa.namespace" . }}
+  labels:
+    {{- include "wosa.labels" . | nindent 4 }}
+    app.kubernetes.io/component: kafka
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .Values.kafka.persistence.size }}
+  {{- include "wosa.storageClass" . | nindent 2 }}
+{{- end }}
+{{/* MinIO Data PVC */}}
+{{- if and .Values.minio.enabled .Values.minio.persistence.enabled }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "wosa.minio.name" . }}-data
+  namespace: {{ include "wosa.namespace" . }}
+  labels:
+    {{- include "wosa.labels" . | nindent 4 }}
+    app.kubernetes.io/component: minio
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .Values.minio.persistence.size }}
+  {{- include "wosa.storageClass" . | nindent 2 }}
+{{- end }}
+{{/* etcd Data PVC */}}
+{{- if and .Values.etcd.enabled .Values.etcd.persistence.enabled }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "wosa.etcd.name" . }}-data
+  namespace: {{ include "wosa.namespace" . }}
+  labels:
+    {{- include "wosa.labels" . | nindent 4 }}
+    app.kubernetes.io/component: etcd
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .Values.etcd.persistence.size }}
+  {{- include "wosa.storageClass" . | nindent 2 }}
+{{- end }}
+{{/* Milvus Data PVC */}}
+{{- if and .Values.milvus.enabled .Values.milvus.persistence.enabled }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "wosa.milvus.name" . }}-data
+  namespace: {{ include "wosa.namespace" . }}
+  labels:
+    {{- include "wosa.labels" . | nindent 4 }}
+    app.kubernetes.io/component: milvus
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .Values.milvus.persistence.size }}
+  {{- include "wosa.storageClass" . | nindent 2 }}
+{{- end }}

--- a/deploy/helm/wosa/templates/redis-deployment.yaml
+++ b/deploy/helm/wosa/templates/redis-deployment.yaml
@@ -1,0 +1,124 @@
+{{- if .Values.redis.enabled }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "wosa.redis.name" . }}
+  namespace: {{ include "wosa.namespace" . }}
+  labels:
+    {{- include "wosa.labels" . | nindent 4 }}
+    app.kubernetes.io/component: redis
+spec:
+  replicas: {{ .Values.redis.replicas }}
+  selector:
+    matchLabels:
+      {{- include "wosa.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: redis
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        {{- include "wosa.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: redis
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      serviceAccountName: {{ include "wosa.serviceAccountName" . }}
+      {{- include "wosa.imagePullSecrets" . | nindent 6 }}
+      {{- include "wosa.podSecurityContext" . | nindent 6 }}
+      containers:
+        - name: redis
+          image: "{{ .Values.redis.image.repository }}:{{ .Values.redis.image.tag }}"
+          imagePullPolicy: {{ .Values.redis.image.pullPolicy }}
+          ports:
+            - name: redis
+              containerPort: {{ .Values.redis.port }}
+              protocol: TCP
+          resources:
+            {{- toYaml .Values.redis.resources | nindent 12 }}
+          {{- include "wosa.containerSecurityContext" . | nindent 10 }}
+          livenessProbe:
+            exec:
+              command: ["redis-cli", "ping"]
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
+          readinessProbe:
+            exec:
+              command: ["redis-cli", "ping"]
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 3
+          {{- if .Values.redis.persistence.enabled }}
+          volumeMounts:
+            - name: data
+              mountPath: /data
+          {{- end }}
+        {{- if .Values.monitoring.enabled }}
+        - name: redis-exporter
+          image: "{{ .Values.monitoring.exporters.redis.image.repository }}:{{ .Values.monitoring.exporters.redis.image.tag }}"
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: metrics
+              containerPort: 9121
+              protocol: TCP
+          env:
+            - name: REDIS_ADDR
+              value: "redis://localhost:{{ .Values.redis.port }}"
+          resources:
+            requests:
+              cpu: "50m"
+              memory: "64Mi"
+            limits:
+              cpu: "200m"
+              memory: "128Mi"
+          {{- include "wosa.containerSecurityContext" . | nindent 10 }}
+        {{- end }}
+
+      {{- if .Values.redis.persistence.enabled }}
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: {{ include "wosa.redis.name" . }}-data
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "wosa.redis.name" . }}
+  namespace: {{ include "wosa.namespace" . }}
+  labels:
+    {{- include "wosa.labels" . | nindent 4 }}
+    app.kubernetes.io/component: redis
+spec:
+  selector:
+    {{- include "wosa.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: redis
+  ports:
+    - name: redis
+      port: {{ .Values.redis.port }}
+      targetPort: redis
+      protocol: TCP
+    {{- if .Values.monitoring.enabled }}
+    - name: metrics
+      port: 9121
+      targetPort: metrics
+      protocol: TCP
+    {{- end }}
+{{- end }}

--- a/deploy/helm/wosa/templates/secrets.yaml
+++ b/deploy/helm/wosa/templates/secrets.yaml
@@ -1,0 +1,59 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "wosa.secret.name" . }}
+  namespace: {{ include "wosa.namespace" . }}
+  labels:
+    {{- include "wosa.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  nvidia-api-key: {{ .Values.secrets.nvidiaApiKey | default .Values.openshift.ngcSecret.password | default "" | quote }}
+  embedding-api-key: {{ .Values.secrets.embeddingApiKey | default "" | quote }}
+  rail-api-key: {{ .Values.secrets.railApiKey | default "" | quote }}
+  nemo-retriever-api-key: {{ .Values.secrets.nemoRetrieverApiKey | default "" | quote }}
+  nemo-ocr-api-key: {{ .Values.secrets.nemoOcrApiKey | default "" | quote }}
+  nemo-parse-api-key: {{ .Values.secrets.nemoParseApiKey | default "" | quote }}
+  llama-nano-vl-api-key: {{ .Values.secrets.llamaNanoVlApiKey | default "" | quote }}
+  jwt-secret-key: {{ .Values.secrets.jwtSecretKey | default "your-strong-random-secret-minimum-32-characters-change-this-in-production" | quote }}
+  postgres-user: {{ .Values.secrets.postgresUser | default "warehouse" | quote }}
+  postgres-password: {{ .Values.secrets.postgresPassword | default "changeme" | quote }}
+  postgres-db: {{ .Values.secrets.postgresDb | default "warehouse" | quote }}
+  default-user-password: {{ .Values.secrets.defaultUserPassword | default "changeme" | quote }}
+  minio-access-key: {{ .Values.secrets.minioAccessKey | default "minioadmin" | quote }}
+  minio-secret-key: {{ .Values.secrets.minioSecretKey | default "minioadmin" | quote }}
+
+{{- if .Values.openshift.enabled }}
+{{- if .Values.openshift.ngcSecret.password }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.openshift.ngcSecret.name }}
+  namespace: {{ include "wosa.namespace" . }}
+  labels:
+    {{- include "wosa.labels" . | nindent 4 }}
+type: kubernetes.io/dockerconfigjson
+stringData:
+  .dockerconfigjson: |
+    {
+      "auths": {
+        "{{ .Values.openshift.ngcSecret.registry }}": {
+          "username": {{ .Values.openshift.ngcSecret.username | quote }},
+          "password": {{ .Values.openshift.ngcSecret.password | quote }}
+        }
+      }
+    }
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.openshift.ngcSecret.apiName }}
+  namespace: {{ include "wosa.namespace" . }}
+  labels:
+    {{- include "wosa.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  NGC_API_KEY: {{ .Values.openshift.ngcSecret.password | default "" | quote }}
+{{- end }}
+{{- end }}

--- a/deploy/helm/wosa/templates/serviceaccount.yaml
+++ b/deploy/helm/wosa/templates/serviceaccount.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "wosa.serviceAccountName" . }}
+  namespace: {{ include "wosa.namespace" . }}
+  labels:
+    {{- include "wosa.labels" . | nindent 4 }}
+{{- if and .Values.openshift.enabled .Values.openshift.imageRegistryPull }}
+---
+# Allow the service account to pull images from the internal OpenShift registry.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "wosa.serviceAccountName" . }}-image-puller
+  namespace: {{ include "wosa.namespace" . }}
+  labels:
+    {{- include "wosa.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:image-puller
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "wosa.serviceAccountName" . }}
+    namespace: {{ include "wosa.namespace" . }}
+{{- end }}

--- a/deploy/helm/wosa/templates/timescaledb-deployment.yaml
+++ b/deploy/helm/wosa/templates/timescaledb-deployment.yaml
@@ -1,0 +1,152 @@
+{{- if .Values.timescaledb.enabled }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "wosa.timescaledb.name" . }}
+  namespace: {{ include "wosa.namespace" . }}
+  labels:
+    {{- include "wosa.labels" . | nindent 4 }}
+    app.kubernetes.io/component: timescaledb
+spec:
+  replicas: {{ .Values.timescaledb.replicas }}
+  selector:
+    matchLabels:
+      {{- include "wosa.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: timescaledb
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        {{- include "wosa.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: timescaledb
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      serviceAccountName: {{ include "wosa.serviceAccountName" . }}
+      {{- include "wosa.imagePullSecrets" . | nindent 6 }}
+      {{- include "wosa.podSecurityContext" . | nindent 6 }}
+      containers:
+        - name: timescaledb
+          image: "{{ .Values.timescaledb.image.repository }}:{{ .Values.timescaledb.image.tag }}"
+          imagePullPolicy: {{ .Values.timescaledb.image.pullPolicy }}
+          ports:
+            - name: postgres
+              containerPort: {{ .Values.timescaledb.port }}
+              protocol: TCP
+          resources:
+            {{- toYaml .Values.timescaledb.resources | nindent 12 }}
+          {{- include "wosa.containerSecurityContext" . | nindent 10 }}
+          livenessProbe:
+            tcpSocket:
+              port: postgres
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            tcpSocket:
+              port: postgres
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 3
+          env:
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "wosa.secret.name" . }}
+                  key: postgres-user
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "wosa.secret.name" . }}
+                  key: postgres-password
+            - name: POSTGRES_DB
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "wosa.secret.name" . }}
+                  key: postgres-db
+          {{- if .Values.timescaledb.persistence.enabled }}
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data
+          {{- end }}
+        {{- if .Values.monitoring.enabled }}
+        - name: postgres-exporter
+          image: "{{ .Values.monitoring.exporters.postgres.image.repository }}:{{ .Values.monitoring.exporters.postgres.image.tag }}"
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: metrics
+              containerPort: 9187
+              protocol: TCP
+          env:
+            - name: DATA_SOURCE_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "wosa.secret.name" . }}
+                  key: postgres-user
+            - name: DATA_SOURCE_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "wosa.secret.name" . }}
+                  key: postgres-password
+            - name: DATA_SOURCE_URI
+              value: "localhost:{{ .Values.timescaledb.port }}/{{ .Values.secrets.postgresDb }}?sslmode=disable"
+          resources:
+            requests:
+              cpu: "50m"
+              memory: "64Mi"
+            limits:
+              cpu: "200m"
+              memory: "128Mi"
+          {{- include "wosa.containerSecurityContext" . | nindent 10 }}
+        {{- end }}
+
+      {{- if .Values.timescaledb.persistence.enabled }}
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: {{ include "wosa.timescaledb.name" . }}-data
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "wosa.timescaledb.name" . }}
+  namespace: {{ include "wosa.namespace" . }}
+  labels:
+    {{- include "wosa.labels" . | nindent 4 }}
+    app.kubernetes.io/component: timescaledb
+spec:
+  selector:
+    {{- include "wosa.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: timescaledb
+  ports:
+    - name: postgres
+      port: {{ .Values.timescaledb.port }}
+      targetPort: postgres
+      protocol: TCP
+    {{- if .Values.monitoring.enabled }}
+    - name: metrics
+      port: 9187
+      targetPort: metrics
+      protocol: TCP
+    {{- end }}
+{{- end }}

--- a/deploy/helm/wosa/templates/user-init-job.yaml
+++ b/deploy/helm/wosa/templates/user-init-job.yaml
@@ -1,0 +1,80 @@
+{{- if .Values.userInit.enabled }}
+---
+# Job: creates default admin + test users in PostgreSQL.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "wosa.fullname" . }}-user-init
+  namespace: {{ include "wosa.namespace" . }}
+  labels:
+    {{- include "wosa.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": post-install
+    "helm.sh/hook-weight": "1"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 5
+  template:
+    metadata:
+      labels:
+        {{- include "wosa.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- include "wosa.podSecurityContext" . | nindent 6 }}
+      {{- include "wosa.imagePullSecrets" . | nindent 6 }}
+      serviceAccountName: {{ include "wosa.serviceAccountName" . }}
+      restartPolicy: OnFailure
+      containers:
+        - name: user-init
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- include "wosa.containerSecurityContext" . | nindent 10 }}
+          command:
+            - sh
+            - -c
+            - |
+              echo "Waiting for TimescaleDB to be ready..."
+              until python -c "
+              import asyncio, asyncpg, os
+              async def check():
+                  conn = await asyncpg.connect(
+                      host=os.environ['PGHOST'], port=int(os.environ['PGPORT']),
+                      user=os.environ['POSTGRES_USER'], password=os.environ['POSTGRES_PASSWORD'],
+                      database=os.environ['POSTGRES_DB'])
+                  await conn.close()
+              asyncio.run(check())
+              " 2>/dev/null; do
+                echo "  not ready, retrying in 5s..."
+                sleep 5
+              done
+              echo "Running create_default_users.py..."
+              python scripts/setup/create_default_users.py
+          env:
+            - name: PGHOST
+              value: {{ include "wosa.timescaledb.name" . | quote }}
+            - name: PGPORT
+              value: {{ .Values.timescaledb.port | quote }}
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "wosa.secret.name" . }}
+                  key: postgres-user
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "wosa.secret.name" . }}
+                  key: postgres-password
+            - name: POSTGRES_DB
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "wosa.secret.name" . }}
+                  key: postgres-db
+            - name: DEFAULT_ADMIN_PASSWORD
+              value: {{ .Values.backend.env.defaultAdminPassword | quote }}
+            - name: DEFAULT_USER_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "wosa.secret.name" . }}
+                  key: default-user-password
+            - name: PYTHONPATH
+              value: /app
+{{- end }}

--- a/deploy/helm/wosa/values-openshift.yaml
+++ b/deploy/helm/wosa/values-openshift.yaml
@@ -1,0 +1,181 @@
+# values-openshift.yaml — OpenShift overlay for Multi-Agent Intelligent Warehouse (WOSA).
+#
+# Usage:
+#   helm install wosa ./deploy/helm/wosa \
+#     -n wosa --create-namespace \
+#     -f ./deploy/helm/wosa/values-openshift.yaml \
+#     --set openshift.ngcSecret.password="$NVIDIA_API_KEY"
+#
+# This file enables OpenShift-specific resources (Route, SCC, nginx proxy,
+# credential Secrets) and switches from hosted NVIDIA API endpoints to NIM
+# Operator managed services.  Cluster-specific values (tolerations,
+# storageClass, NGC keys) should be passed via --set at install time.
+
+# ---------------------------------------------------------------------------
+# OpenShift features
+# ---------------------------------------------------------------------------
+openshift:
+  enabled: true
+  route:
+    enabled: true
+    host: ""
+    tls:
+      termination: edge
+      insecureEdgeTerminationPolicy: Redirect
+    timeout: "5m"
+  scc:
+    create: true
+    priority: 10
+  imageRegistryPull: true
+
+# ---------------------------------------------------------------------------
+# Application images
+# ---------------------------------------------------------------------------
+image:
+  repository: image-registry.openshift-image-registry.svc:5000/wosa/wosa-backend
+
+frontend:
+  image:
+    repository: image-registry.openshift-image-registry.svc:5000/wosa/wosa-frontend
+
+service:
+  type: ClusterIP
+
+# ---------------------------------------------------------------------------
+# Backend timeout overrides for self-hosted NIM inference
+# Self-hosted models have higher latency than the hosted NVIDIA API;
+# increase agent/graph/chat timeouts to prevent premature timeouts.
+# ---------------------------------------------------------------------------
+backend:
+  env:
+    agentTimeoutSimple: "90"
+    agentTimeoutComplex: "120"
+    agentTimeoutReasoning: "180"
+    graphTimeoutSimple: "120"
+    graphTimeoutComplex: "180"
+    chatTimeoutSimple: "120"
+    chatTimeoutComplex: "180"
+
+# ---------------------------------------------------------------------------
+# NIM Operator integration — deploys LLM and embedding NIMs via NIMCache +
+# NIMService.  The NIM Operator handles model downloading, caching, and GPU
+# scheduling.
+# Requires: NIM Operator installed, NGC image-pull and API secrets in namespace.
+# ---------------------------------------------------------------------------
+nimOperator:
+  llm:
+    enabled: true
+    replicas: 1
+    service:
+      name: "nim-llm"
+    image:
+      repository: nvcr.io/nim/nvidia/llama-3.3-nemotron-super-49b-v1.5
+      tag: "latest"
+      pullPolicy: Always
+    # Profile filter — avoids downloading all 24 profiles (~2.4 TB).
+    # fp8/tp=2 fits L40S, A100-80GB, H100. Override: bf16 (max accuracy), nvfp4 (A100-40GB).
+    model:
+      precision: "fp8"
+      tensorParallelism: "2"
+      profile: ""
+    resources:
+      limits:
+        nvidia.com/gpu: 2
+      requests:
+        nvidia.com/gpu: 2
+    storage:
+      pvc:
+        create: true
+        size: "500Gi"
+        volumeAccessMode: ReadWriteOnce
+        storageClass: ""
+    nodeSelector: {}
+    tolerations:
+      - key: nvidia.com/gpu
+        operator: Exists
+        effect: NoSchedule
+      # Add cluster-specific tolerations as needed:
+      # - key: <your-gpu-taint-key>
+      #   operator: Equal
+      #   value: "true"
+      #   effect: NoSchedule
+    env:
+      - name: NIM_HTTP_API_PORT
+        value: "8000"
+      - name: TOKENIZERS_PARALLELISM
+        value: "false"
+    expose:
+      service:
+        name: http
+        type: ClusterIP
+        port: 8000
+    startupProbe:
+      enabled: true
+      probe:
+        httpGet:
+          path: /v1/health/ready
+          port: 8000
+        initialDelaySeconds: 60
+        periodSeconds: 30
+        failureThreshold: 120
+
+  embedding:
+    enabled: true
+    replicas: 1
+    service:
+      name: "nim-embedding"
+    image:
+      repository: nvcr.io/nim/nvidia/llama-nemotron-embed-vl-1b-v2
+      tag: "1.12.0"
+      pullPolicy: Always
+    resources:
+      limits:
+        nvidia.com/gpu: 1
+      requests:
+        nvidia.com/gpu: 1
+    storage:
+      pvc:
+        create: true
+        size: "100Gi"
+        volumeAccessMode: ReadWriteOnce
+        storageClass: ""
+    nodeSelector: {}
+    tolerations:
+      - key: nvidia.com/gpu
+        operator: Exists
+        effect: NoSchedule
+      # Add cluster-specific tolerations as needed:
+      # - key: <your-gpu-taint-key>
+      #   operator: Equal
+      #   value: "true"
+      #   effect: NoSchedule
+    env:
+      - name: NIM_HTTP_API_PORT
+        value: "8000"
+      - name: TOKENIZERS_PARALLELISM
+        value: "false"
+    expose:
+      service:
+        name: http
+        type: ClusterIP
+        port: 8000
+    startupProbe:
+      enabled: true
+      probe:
+        httpGet:
+          path: /v1/health/ready
+          port: 8000
+        initialDelaySeconds: 60
+        periodSeconds: 30
+        failureThreshold: 120
+
+# ---------------------------------------------------------------------------
+# Milvus GPU acceleration (optional)
+# ---------------------------------------------------------------------------
+milvus:
+  gpu:
+    enabled: false
+    # tolerations:
+    #   - key: "nvidia.com/gpu"
+    #     operator: Exists
+    #     effect: NoSchedule

--- a/deploy/helm/wosa/values.yaml
+++ b/deploy/helm/wosa/values.yaml
@@ -1,0 +1,519 @@
+# WOSA Helm Chart Values
+#
+# Required overrides (must be set at deploy time):
+#   secrets.nvidiaApiKey
+
+# ---------------------------------------------------------------------------
+# Global Settings
+# ---------------------------------------------------------------------------
+nameOverride: ""
+fullnameOverride: ""
+namespace: ""
+storageClass: ""
+imagePullSecrets: []
+podAnnotations: {}
+nodeSelector: {}
+tolerations: []
+affinity: {}
+
+serviceAccount:
+  name: wosa-sa
+
+# ---------------------------------------------------------------------------
+# Application Images
+# ---------------------------------------------------------------------------
+image:
+  repository: ""   # REQUIRED: set to your backend image (e.g. quay.io/myorg/wosa-backend)
+  tag: "latest"
+  pullPolicy: Always
+
+# ---------------------------------------------------------------------------
+# Backend
+# ---------------------------------------------------------------------------
+backend:
+  replicas: 1
+  port: 8001
+  resources:
+    requests:
+      cpu: "500m"
+      memory: "1Gi"
+    limits:
+      cpu: "2"
+      memory: "4Gi"
+  env:
+    environment: production
+    # LLM
+    llmNimUrl: "https://integrate.api.nvidia.com/v1"
+    llmModel: "nvidia/llama-3.3-nemotron-super-49b-v1.5"
+    llmTemperature: "0.1"
+    llmMaxTokens: "2000"
+    llmTopP: "1.0"
+    llmFrequencyPenalty: "0.0"
+    llmPresencePenalty: "0.0"
+    llmClientTimeout: "120"
+    llmCacheEnabled: "true"
+    llmCacheTtlSeconds: "300"
+    # Embedding
+    embeddingNimUrl: "https://integrate.api.nvidia.com/v1"
+    embeddingModel: "nvidia/llama-nemotron-embed-vl-1b-v2"
+    # NeMo document processing
+    nemoRetrieverUrl: "https://integrate.api.nvidia.com/v1"
+    nemoOcrUrl: "https://integrate.api.nvidia.com/v1"
+    nemoParseUrl: "https://integrate.api.nvidia.com/v1"
+    llamaNanoVlUrl: "https://integrate.api.nvidia.com/v1"
+    # Guardrails
+    railApiUrl: "https://integrate.api.nvidia.com/v1"
+    guardrailsTimeout: "10"
+    guardrailsUseApi: "false"
+    useNemoGuardrailsSdk: "false"
+    guardrailsModel: "nvidia/llama-3.3-nemotron-super-49b-v1.5"
+    # LLM Judge
+    llama70bTimeout: "120"
+    # Service discovery
+    dbPort: "5432"
+    redisPort: "6379"
+    redisDb: "0"
+    milvusPort: "19530"
+    milvusUser: "root"
+    milvusPassword: "Milvus"
+    milvusCollectionName: "warehouse_docs"
+    # Application
+    corsOrigins: ""
+    maxRequestSize: "10485760"
+    maxUploadSize: "52428800"
+    maxPdfPagesToProcess: "5"
+    maxPdfPagesToExtract: "10"
+    defaultAdminPassword: "changeme"
+  healthCheck:
+    path: /api/v1/health
+    initialDelaySeconds: 30
+    periodSeconds: 10
+
+# ---------------------------------------------------------------------------
+# Security Contexts (restricted-v2 compatible)
+# ---------------------------------------------------------------------------
+securityContext:
+  runAsNonRoot: true
+  seccompProfile:
+    type: RuntimeDefault
+
+containerSecurityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+
+# ---------------------------------------------------------------------------
+# Application secrets (converted from Docker Compose .env)
+# ---------------------------------------------------------------------------
+secrets:
+  nvidiaApiKey: ""
+  embeddingApiKey: ""
+  railApiKey: ""
+  nemoRetrieverApiKey: ""
+  nemoOcrApiKey: ""
+  nemoParseApiKey: ""
+  llamaNanoVlApiKey: ""
+  defaultUserPassword: "changeme"
+  jwtSecretKey: "your-strong-random-secret-minimum-32-characters-change-this-in-production"
+  postgresUser: "warehouse"
+  postgresPassword: "changeme"
+  postgresDb: "warehouse"
+  minioAccessKey: "minioadmin"
+  minioSecretKey: "minioadmin"
+
+# ---------------------------------------------------------------------------
+# Infrastructure Services
+# ---------------------------------------------------------------------------
+
+# TimescaleDB
+timescaledb:
+  enabled: true
+  replicas: 1
+  image:
+    repository: timescale/timescaledb
+    tag: "2.15.2-pg16"
+    pullPolicy: IfNotPresent
+  port: 5432
+  persistence:
+    enabled: true
+    size: 10Gi
+  resources:
+    requests:
+      cpu: "250m"
+      memory: "512Mi"
+    limits:
+      cpu: "1"
+      memory: "2Gi"
+
+# Redis
+redis:
+  enabled: true
+  replicas: 1
+  image:
+    repository: redis
+    tag: "7"
+    pullPolicy: IfNotPresent
+  port: 6379
+  persistence:
+    enabled: true
+    size: 2Gi
+  resources:
+    requests:
+      cpu: "100m"
+      memory: "128Mi"
+    limits:
+      cpu: "500m"
+      memory: "512Mi"
+
+# Kafka
+kafka:
+  enabled: true
+  replicas: 1
+  image:
+    repository: apache/kafka
+    tag: "3.7.0"
+    pullPolicy: IfNotPresent
+  port: 9092
+  persistence:
+    enabled: true
+    size: 5Gi
+  clusterId: "MkU3OEVBNTcwNTJENDM2Qk"
+  resources:
+    requests:
+      cpu: "250m"
+      memory: "512Mi"
+    limits:
+      cpu: "1"
+      memory: "2Gi"
+
+# etcd
+etcd:
+  enabled: true
+  replicas: 1
+  image:
+    repository: quay.io/coreos/etcd
+    tag: "v3.5.9"
+    pullPolicy: IfNotPresent
+  port: 2379
+  persistence:
+    enabled: true
+    size: 1Gi
+  resources:
+    requests:
+      cpu: "100m"
+      memory: "128Mi"
+    limits:
+      cpu: "500m"
+      memory: "512Mi"
+
+# MinIO
+minio:
+  enabled: true
+  replicas: 1
+  image:
+    repository: minio/minio
+    tag: "RELEASE.2024-03-15T01-07-19Z"
+    pullPolicy: IfNotPresent
+  service:
+    apiPort: 9000
+    consolePort: 9001
+  persistence:
+    enabled: true
+    size: 10Gi
+  resources:
+    requests:
+      cpu: "250m"
+      memory: "512Mi"
+    limits:
+      cpu: "1"
+      memory: "2Gi"
+
+# Milvus
+milvus:
+  enabled: true
+  replicas: 1
+  image:
+    repository: milvusdb/milvus
+    tag: "v2.4.3"
+    pullPolicy: IfNotPresent
+  port: 19530
+  httpPort: 9091
+  persistence:
+    enabled: true
+    size: 10Gi
+  gpu:
+    enabled: false
+    deviceId: "0"
+    tolerations: []
+  resources:
+    requests:
+      cpu: "500m"
+      memory: "1Gi"
+    limits:
+      cpu: "2"
+      memory: "4Gi"
+
+# ---------------------------------------------------------------------------
+# Frontend & Routing
+# ---------------------------------------------------------------------------
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  hosts: []
+  tls: []
+
+service:
+  type: ClusterIP
+
+# Frontend
+frontend:
+  enabled: true
+  replicas: 1
+  image:
+    repository: ""   # REQUIRED: set to your frontend image (e.g. quay.io/myorg/wosa-frontend)
+    tag: "latest"
+    pullPolicy: Always
+  service:
+    port: 8080
+  healthCheck:
+    path: /
+    initialDelaySeconds: 10
+    periodSeconds: 10
+  resources:
+    requests:
+      cpu: "50m"
+      memory: "64Mi"
+    limits:
+      cpu: "200m"
+      memory: "128Mi"
+
+# Nginx
+nginx:
+  enabled: true
+  replicas: 1
+  image:
+    repository: nginxinc/nginx-unprivileged
+    tag: 1.25-alpine
+    pullPolicy: IfNotPresent
+  service:
+    port: 8080
+  resources:
+    requests:
+      cpu: "50m"
+      memory: "64Mi"
+    limits:
+      cpu: "200m"
+      memory: "128Mi"
+
+# ---------------------------------------------------------------------------
+# Network Policy
+# ---------------------------------------------------------------------------
+networkPolicy:
+  enabled: true
+
+# ---------------------------------------------------------------------------
+# Helm Hook Jobs
+# ---------------------------------------------------------------------------
+
+dbInit:
+  enabled: true
+
+userInit:
+  enabled: true
+
+demoData:
+  enabled: false
+
+demoDemand:
+  enabled: false
+
+# ---------------------------------------------------------------------------
+# Monitoring
+# ---------------------------------------------------------------------------
+monitoring:
+  enabled: false
+
+  alertmanager:
+    enabled: true
+    groupWait: 10s
+    groupInterval: 10s
+    repeatInterval: 1h
+    smtp:
+      smarthost: "localhost:587"
+      from: "alerts@warehouse-assistant.com"
+    receivers:
+      critical:
+        email: "admin@warehouse-assistant.com"
+        webhookUrl: "http://localhost:5001/critical"
+        subject: "[CRITICAL] Warehouse Alert: {{ .GroupLabels.alertname }}"
+      warning:
+        email: "operations@warehouse-assistant.com"
+        webhookUrl: "http://localhost:5001/warning"
+        subject: "[WARNING] Warehouse Alert: {{ .GroupLabels.alertname }}"
+      default:
+        webhookUrl: "http://localhost:5001/"
+
+  alerts:
+    highMemoryThresholdGiB: 3.2
+
+  exporters:
+    postgres:
+      image:
+        repository: prometheuscommunity/postgres-exporter
+        tag: "latest"
+    redis:
+      image:
+        repository: oliver006/redis_exporter
+        tag: "latest"
+
+  serviceMonitor:
+    interval: 30s
+    scrapeTimeout: 10s
+    metricsPath: /api/v1/metrics
+
+  prometheusRules:
+    enabled: true
+
+  grafana:
+    enabled: true
+    adminPassword: "changeme"
+    createOperatorGroup: true
+    channel: "v5"
+    catalogSource: community-operators
+    catalogSourceNamespace: openshift-marketplace
+    replicas: 1
+    resources:
+      requests:
+        cpu: "100m"
+        memory: "256Mi"
+      limits:
+        cpu: "500m"
+        memory: "512Mi"
+    datasource:
+      url: "https://thanos-querier.openshift-monitoring.svc.cluster.local:9091"
+    dashboards:
+      enabled: true
+
+# ---------------------------------------------------------------------------
+# NIM Operator integration (disabled by default).
+# When enabled AND the NIM Operator CRD is present on the cluster, NIMCache +
+# NIMService resources are created for self-hosted LLM and embedding inference
+# instead of using the hosted NVIDIA API (integrate.api.nvidia.com).
+# Disable the hosted API endpoints by setting nimOperator.<nim>.enabled: true
+# in your overlay to avoid running both paths.
+# ---------------------------------------------------------------------------
+nimOperator:
+  llm:
+    enabled: false
+    replicas: 1
+    service:
+      name: "nim-llm"
+    image:
+      repository: nvcr.io/nim/nvidia/llama-3.3-nemotron-super-49b-v1.5
+      tag: "latest"
+      pullPolicy: Always
+    model:
+      precision: ""
+      tensorParallelism: ""
+      profile: ""
+    resources:
+      limits:
+        nvidia.com/gpu: 2
+      requests:
+        nvidia.com/gpu: 2
+    storage:
+      pvc:
+        create: true
+        size: "500Gi"
+        volumeAccessMode: ReadWriteOnce
+        storageClass: ""
+    nodeSelector: {}
+    tolerations: []
+    env:
+      - name: NIM_HTTP_API_PORT
+        value: "8000"
+      - name: TOKENIZERS_PARALLELISM
+        value: "false"
+    expose:
+      service:
+        name: http
+        type: ClusterIP
+        port: 8000
+    startupProbe:
+      enabled: true
+      probe:
+        httpGet:
+          path: /v1/health/ready
+          port: 8000
+        initialDelaySeconds: 60
+        periodSeconds: 30
+        failureThreshold: 120
+
+  embedding:
+    enabled: false
+    replicas: 1
+    service:
+      name: "nim-embedding"
+    image:
+      repository: nvcr.io/nim/nvidia/llama-nemotron-embed-vl-1b-v2
+      tag: "1.12.0"
+      pullPolicy: Always
+    resources:
+      limits:
+        nvidia.com/gpu: 1
+      requests:
+        nvidia.com/gpu: 1
+    storage:
+      pvc:
+        create: true
+        size: "100Gi"
+        volumeAccessMode: ReadWriteOnce
+        storageClass: ""
+    nodeSelector: {}
+    tolerations: []
+    env:
+      - name: NIM_HTTP_API_PORT
+        value: "8000"
+      - name: TOKENIZERS_PARALLELISM
+        value: "false"
+    expose:
+      service:
+        name: http
+        type: ClusterIP
+        port: 8000
+    startupProbe:
+      enabled: true
+      probe:
+        httpGet:
+          path: /v1/health/ready
+          port: 8000
+        initialDelaySeconds: 60
+        periodSeconds: 30
+        failureThreshold: 120
+
+# ---------------------------------------------------------------------------
+# OpenShift support (disabled by default — zero impact on vanilla Kubernetes)
+# ---------------------------------------------------------------------------
+openshift:
+  enabled: false
+  ngcSecret:
+    name: "ngc-secret"
+    apiName: "ngc-api"
+    registry: "nvcr.io"
+    username: "$oauthtoken"
+    password: ""
+  route:
+    enabled: false
+    host: ""
+    tls:
+      termination: edge
+      insecureEdgeTerminationPolicy: Redirect
+    timeout: "5m"
+    annotations: {}
+  scc:
+    create: false
+    priority: 10
+  imageRegistryPull: false

--- a/docs/deployment/openshift-deployment.md
+++ b/docs/deployment/openshift-deployment.md
@@ -1,0 +1,486 @@
+# Deploying NVIDIA Multi-Agent Intelligent Warehouse on Red Hat OpenShift AI
+
+## What We're Deploying
+
+The Multi-Agent Intelligent Warehouse (WOSA) Blueprint is an AI-powered operations
+assistant that combines multi-agent orchestration (LangGraph) with NVIDIA NIM inference
+services to deliver intelligent warehouse management — operations, safety, equipment
+tracking, demand forecasting, and document processing.
+
+| Component | Image | GPU | Purpose |
+|-----------|-------|-----|---------|
+| **nim-llm** (NIM Operator) | `nvcr.io/nim/nvidia/llama-3.3-nemotron-super-49b-v1.5` | 2 | LLM inference via NIMService |
+| **nim-embedding** (NIM Operator) | `nvcr.io/nim/nvidia/llama-nemotron-embed-vl-1b-v2` | 1 | Vector embedding via NIMService |
+| **wosa-backend** | Internal or external registry | 0 | FastAPI multi-agent orchestration API |
+| **wosa-frontend** | Internal or external registry | 0 | React web UI |
+| **wosa-nginx** | `nginxinc/nginx-unprivileged:1.25-alpine` | 0 | Reverse proxy (Route entry point) |
+| **wosa-timescaledb** | `timescale/timescaledb:2.15.2-pg16` | 0 | Time-series relational database |
+| **wosa-redis** | `redis:7` | 0 | Caching and session storage |
+| **wosa-milvus** | `milvusdb/milvus:v2.4.3` | 0 (optional 1) | Vector database for RAG |
+| **wosa-etcd** | `quay.io/coreos/etcd:v3.5.9` | 0 | Milvus metadata store |
+| **wosa-minio** | `minio/minio` | 0 | Milvus object storage |
+| **wosa-kafka** | `apache/kafka:3.7.0` | 0 | Event streaming (KRaft) |
+
+**Total:** 3 GPUs minimum (2 LLM + 1 embedding). Optional 4th GPU if `milvus.gpu.enabled=true`.
+
+### NIM Operator Components
+
+When deployed with the NIM Operator (recommended on OpenShift), each NIM inference
+service is managed as a pair of custom resources:
+
+- **NIMCache** — downloads and caches the model on a PVC. Annotated with
+  `helm.sh/resource-policy: keep` to survive upgrades and uninstalls.
+- **NIMService** — runs the inference server, references its NIMCache for model storage,
+  manages replicas, GPU allocation, and health probes.
+
+## Tested Hardware
+
+| Parameter | Value |
+|-----------|-------|
+| Platform | Red Hat OpenShift AI (RHOAI) 4.14+ |
+| GPU nodes | 1+ nodes with NVIDIA A100 80GB / H100 |
+| GPUs per node | 1+ |
+| Total GPUs | 3 (2 nim-llm + 1 nim-embedding); 4 if Milvus GPU enabled |
+| VRAM | 80 GB+ per GPU (LLM requires 2× A100 80GB or H100) |
+| CPU | 10+ cores across worker nodes |
+| RAM | 32 GB+ |
+| Storage | 638 GiB dynamically provisioned PVCs (500 GiB LLM + 100 GiB embedding) + 38 GiB for infrastructure PVCs |
+| API keys | [NGC API key](https://org.ngc.nvidia.com/setup/api-keys) |
+
+Minimum for reproduction: 3 × NVIDIA A100 80GB / H100 GPUs, 638 GiB storage. Add 1 GPU if `milvus.gpu.enabled=true`.
+
+> **Important — always filter NIMCache downloads.** The `values-openshift.yaml` defaults
+> to `precision=fp8`, `tensorParallelism=2` which fits L40S (48 GB), A100-80GB, and H100.
+> Without filtering, the NIMCache downloads all 24 model profiles (~2.4 TB). These large
+> sustained downloads frequently fail with network timeouts to NGC, causing the download
+> pod to restart from scratch — in practice, unfiltered downloads may **never complete**.
+> With filtering, only the matching profile is downloaded (~200 GB, ~10 minutes).
+>
+> Override for other GPUs:
+> - A100-80GB / H100 (max accuracy): `--set nimOperator.llm.model.precision=bf16`
+> - A100-40GB: `--set nimOperator.llm.model.precision=nvfp4`
+>
+> When overriding precision, wait for the NIMCache to become Ready, then pin the profile:
+> ```bash
+> oc get nimcache nim-llm-cache -n $NAMESPACE -o jsonpath='{.status.profiles[0].name}'
+> ```
+> Pass the result via `helm upgrade --set nimOperator.llm.model.profile=<hash>`.
+
+## What's Different from Upstream
+
+| Area | Upstream Default | OpenShift Deployment | Impact |
+|------|------------------|----------------------|--------|
+| NIM inference (LLM + embedding) | NVIDIA cloud API (`integrate.api.nvidia.com`) | NIM Operator (NIMCache + NIMService) | Self-hosted, air-gappable |
+| External access | `kubectl port-forward` | OpenShift Route with TLS | Production-grade ingress |
+| Security context | Default UIDs | Custom SCC + RoleBinding | Compatible with OpenShift SCC |
+| Secrets | Manual `.env` file | Helm-managed via `--set` | Single `helm install` creates all secrets |
+| Container images | Docker Compose bind mounts | OpenShift-compatible Dockerfiles | Non-root, no bind mounts |
+
+> **Using the cloud API instead of NIM Operator:** Set `nimOperator.llm.enabled: false`
+> and `nimOperator.embedding.enabled: false` in your values overlay. The backend will use
+> the hosted NVIDIA endpoints (`integrate.api.nvidia.com/v1`) and no GPU nodes are
+> required. Only the `NVIDIA_API_KEY` secret is needed.
+
+## Deployment Files
+
+All OpenShift customizations are in the `deploy/` folder. The upstream codebase is modified only where strictly necessary (env var fallbacks for DB connections and file paths).
+
+- **`Dockerfile.backend-openshift`**, **`Dockerfile.frontend-openshift`** — OpenShift-compatible container images (non-root, no bind mounts).
+- **`deploy/helm/wosa/`** — Full Helm chart: deployment templates for all services, hook jobs, monitoring, network policies, secrets, PVCs, OpenShift Route and SCC, NIMCache + NIMService templates for LLM and embedding (gated by `apps.nvidia.com/v1alpha1`), and conditional NIM URL resolution in the backend.
+- **Source code changes** — Env var fallbacks (`PGHOST`, `PGPORT`, `REDIS_HOST`, `FORECAST_OUTPUT_DIR`) in 6 Python files, and configurable agent/graph/chat timeouts (`AGENT_TIMEOUT_SIMPLE`, `GRAPH_TIMEOUT_COMPLEX`, etc.) in 2 Python files. All changes preserve original defaults.
+
+## Prerequisites
+
+### CLI Tools
+
+- `oc` (OpenShift CLI) logged into your cluster
+- `helm` v3.12+
+- `podman` (for building and pushing images to an external registry)
+
+### Cluster Requirements
+
+- Red Hat OpenShift 4.14+
+- NVIDIA GPU Operator installed and configured
+- NIM Operator installed (provides `apps.nvidia.com/v1alpha1` API)
+- At least 3 GPUs available (can be on 1+ nodes)
+
+### Verify GPU Availability
+
+```bash
+oc get nodes -l nvidia.com/gpu.present=true
+oc describe node <gpu-node> | grep -A 5 "Allocatable"
+```
+
+## Configuration Reference
+
+### Environment Variables
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `NGC_API_KEY` | Yes | — | NGC API key for image pulls, model downloads, and cloud NIM services |
+
+### OpenShift Block (`openshift:`)
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `openshift.enabled` | `false` | Master toggle for all OpenShift resources |
+| `openshift.route.enabled` | `false` | Create an OpenShift Route for the UI |
+| `openshift.route.host` | `""` | Hostname (auto-generated if empty) |
+| `openshift.route.tls.termination` | `edge` | TLS termination strategy |
+| `openshift.scc.create` | `false` | Create custom SCC + RoleBinding |
+| `openshift.scc.priority` | `10` | SCC priority |
+| `openshift.imageRegistryPull` | `false` | Grant SA permission to pull from internal registry |
+| `openshift.ngcSecret.name` | `ngc-secret` | Name of the image pull secret |
+| `openshift.ngcSecret.apiName` | `ngc-api` | Name of the NGC API secret |
+| `openshift.ngcSecret.registry` | `nvcr.io` | Container registry for NGC images |
+| `openshift.ngcSecret.username` | `$oauthtoken` | Registry username |
+| `openshift.ngcSecret.password` | `""` | NGC API key (set at install time) |
+
+### NIM Operator Block (`nimOperator:`)
+
+Each NIM (`llm`, `embedding`) shares a common schema. The `model.*` keys apply to the LLM NIM only.
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `enabled` | `false` | Deploy this NIM via NIM Operator |
+| `replicas` | `1` | Number of inference replicas |
+| `service.name` | (per NIM) | Kubernetes service name (used for DNS) |
+| `image.repository` | (per NIM) | NGC container image |
+| `image.tag` | (per NIM) | Image version |
+| `model.precision` | `"fp8"` | Filter NIMCache downloads by precision — LLM only (`bf16`, `fp8`, `nvfp4`) |
+| `model.tensorParallelism` | `"2"` | Filter NIMCache downloads by tensor parallelism — LLM only (e.g. `2`, `4`) |
+| `model.profile` | `""` | Pin NIMService to a specific cached profile hash — LLM only |
+| `resources.limits.nvidia.com/gpu` | `2` (LLM) / `1` (embedding) | GPU allocation |
+| `storage.pvc.size` | `500Gi` (LLM) / `100Gi` (embedding) | Model cache PVC size |
+| `storage.pvc.storageClass` | `""` | StorageClass (uses cluster default if empty) |
+| `expose.service.port` | `8000` | Service port |
+| `tolerations` | `[]` | Node tolerations for GPU taints |
+| `env` | (per NIM) | Environment variables |
+| `startupProbe` | (per NIM) | Startup probe configuration |
+
+## Deployment
+
+### 1. Create Namespace
+
+```bash
+export NGC_API_KEY="<your-ngc-api-key>"
+export NAMESPACE=wosa
+
+oc new-project $NAMESPACE
+```
+
+### 2. Build Application Images
+
+You have two options: use the internal OpenShift registry or push to an external registry.
+
+#### Option A: Internal OpenShift Registry (oc start-build)
+
+```bash
+# Backend
+oc new-build --binary --strategy=docker --name=wosa-backend -n $NAMESPACE
+oc patch buildconfig wosa-backend -n $NAMESPACE \
+  -p '{"spec":{"strategy":{"dockerStrategy":{"dockerfilePath":"Dockerfile.backend-openshift"}}}}'
+oc start-build wosa-backend --from-dir=. --follow -n $NAMESPACE
+
+# Frontend
+oc new-build --binary --strategy=docker --name=wosa-frontend -n $NAMESPACE
+oc patch buildconfig wosa-frontend -n $NAMESPACE \
+  -p '{"spec":{"strategy":{"dockerStrategy":{"dockerfilePath":"Dockerfile.frontend-openshift"}}}}'
+oc start-build wosa-frontend --from-dir=. --follow -n $NAMESPACE
+```
+
+The resulting images are available at
+`image-registry.openshift-image-registry.svc:5000/$NAMESPACE/wosa-backend` and
+`image-registry.openshift-image-registry.svc:5000/$NAMESPACE/wosa-frontend`.
+These are the default image paths in `values-openshift.yaml` — no `--set` override needed.
+
+#### Option B: External Registry (quay.io / Docker Hub)
+
+```bash
+# Build
+podman build -f Dockerfile.backend-openshift -t quay.io/<org>/wosa-backend:latest .
+podman build -f Dockerfile.frontend-openshift -t quay.io/<org>/wosa-frontend:latest .
+
+# Push
+podman login quay.io
+podman push quay.io/<org>/wosa-backend:latest
+podman push quay.io/<org>/wosa-frontend:latest
+```
+
+When using an external registry, override the image paths in step 3:
+
+```bash
+--set image.repository=quay.io/<org>/wosa-backend \
+--set frontend.image.repository=quay.io/<org>/wosa-frontend
+```
+
+### 3. Install the Chart
+
+All secrets — NGC image pull, NGC API, and application secrets — are created
+automatically by the chart from a single `--set`:
+
+```bash
+helm install wosa deploy/helm/wosa/ \
+  -n $NAMESPACE \
+  -f deploy/helm/wosa/values-openshift.yaml \
+  --set openshift.ngcSecret.password="$NGC_API_KEY"
+```
+
+> If using an external registry (Option B above), add the image overrides:
+> ```bash
+> helm install wosa deploy/helm/wosa/ \
+>   -n $NAMESPACE \
+>   -f deploy/helm/wosa/values-openshift.yaml \
+>   --set openshift.ngcSecret.password="$NGC_API_KEY" \
+>   --set image.repository=quay.io/<org>/wosa-backend \
+>   --set frontend.image.repository=quay.io/<org>/wosa-frontend
+> ```
+
+**With optional features:**
+
+```bash
+helm install wosa deploy/helm/wosa/ \
+  -n $NAMESPACE \
+  -f deploy/helm/wosa/values-openshift.yaml \
+  --set openshift.ngcSecret.password="$NGC_API_KEY" \
+  --set demoData.enabled=true \
+  --set demoDemand.enabled=true \
+  --set monitoring.enabled=true
+```
+
+This creates:
+- 2 x NIMCache (model download and caching)
+- 2 x NIMService (inference servers)
+- 1 x OpenShift Route (external UI access)
+- 1 x Custom SCC + RoleBinding (allows NIM and app pods to run as image UIDs)
+- All required secrets (NGC pull, NGC API, application credentials)
+- WOSA application and supporting services (TimescaleDB, Redis, Milvus, Kafka, etc.)
+
+### 4. Monitor Model Downloads
+
+NIMCache resources download models from NGC. The default configuration filters
+downloads to a single profile (~200 GB, ~10 minutes). See the [NIMCache filtering
+note](#tested-hardware) for details on why filtering is critical.
+
+```bash
+oc get nimcache -n $NAMESPACE -w
+```
+
+Wait until all caches show `Ready`:
+
+```
+NAME                  STATUS   AGE
+nim-llm-cache         Ready    30m
+nim-embedding-cache   Ready    15m
+```
+
+## Verification
+
+### Check NIMService Status
+
+```bash
+oc get nimservice -n $NAMESPACE
+```
+
+### Check Pods
+
+```bash
+oc get pods -n $NAMESPACE
+```
+
+All pods should reach `Running 1/1`. Infrastructure pods (TimescaleDB, Milvus) may take
+1-2 minutes. NIM pods wait for their NIMCache to become Ready.
+
+**Expected pods:**
+
+| Pod | Purpose | Managed By |
+|-----|---------|------------|
+| `nim-llm` | LLM inference (Nemotron Super 49B) | NIM Operator |
+| `nim-embedding` | Vector embedding | NIM Operator |
+| `wosa-backend` | Multi-agent orchestration API | Helm |
+| `wosa-frontend` | React web UI | Helm |
+| `wosa-nginx` | Reverse proxy (Route entry point) | Helm |
+| `wosa-timescaledb` | Time-series database | Helm |
+| `wosa-redis` | Cache and sessions | Helm |
+| `wosa-milvus` | Vector database | Helm |
+| `wosa-etcd` | Milvus metadata store | Helm |
+| `wosa-minio` | Milvus object storage | Helm |
+| `wosa-kafka` | Event streaming | Helm |
+
+### Health Endpoints
+
+```bash
+for svc in nim-llm nim-embedding; do
+  echo -n "$svc: "
+  oc exec -n $NAMESPACE deployment/$svc -- curl -s http://localhost:8000/v1/health/ready
+  echo
+done
+
+# Backend health
+ROUTE_HOST=$(oc get route -n $NAMESPACE -l app.kubernetes.io/component=nginx -o jsonpath='{.items[0].spec.host}')
+curl -k https://$ROUTE_HOST/api/v1/health
+```
+
+## Accessing the UI
+
+The Helm chart creates an OpenShift Route with TLS edge termination. Get the URL:
+
+```bash
+ROUTE_HOST=$(oc get route -n $NAMESPACE -l app.kubernetes.io/component=nginx -o jsonpath='{.items[0].spec.host}')
+echo "https://$ROUTE_HOST"
+```
+
+Open `https://$ROUTE_HOST` in a browser. Default credentials: `admin` / `changeme`.
+
+## Database Initialisation and Data Seeding
+
+Schema migrations and post-deploy setup run automatically as Helm hooks on first install.
+
+| Hook Job | Weight | Trigger | What it does |
+|----------|--------|---------|-------------|
+| `db-init-job` | 0 | post-install, post-upgrade | Applies all SQL migrations against TimescaleDB |
+| `user-init-job` | 1 | post-install | Creates `admin` and `user` accounts |
+| `demo-data-job` | 2 | post-install | Seeds inventory, tasks, safety incidents, equipment telemetry |
+| `demo-demand-job` | 3 | post-install | Seeds 180 days of demand history for Forecasting |
+
+**Enabled by default:** `db-init-job` (`dbInit.enabled`), `user-init-job` (`userInit.enabled`).
+**Disabled by default:** `demo-data-job` (`--set demoData.enabled=true`), `demo-demand-job` (`--set demoDemand.enabled=true`).
+
+## Monitoring
+
+When `--set monitoring.enabled=true`, the chart deploys:
+
+1. **ServiceMonitors** (4) — scrape targets for OpenShift's built-in Prometheus
+2. **PrometheusRule** — 14 alert rules
+3. **AlertmanagerConfig** — alert routing with email and webhook receivers
+4. **Grafana Operator** — installed namespace-scoped via OLM
+5. **Grafana instance** — with Route and Thanos Querier datasource
+6. **GrafanaDashboard CRs** — 3 pre-built dashboards (Overview, Operations, Safety)
+
+### Prerequisite (cluster-admin, one-time)
+
+Enable user workload monitoring:
+
+```bash
+oc apply -f - <<EOF
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-monitoring-config
+  namespace: openshift-monitoring
+data:
+  config.yaml: |
+    enableUserWorkload: true
+EOF
+```
+
+### Access Grafana
+
+```bash
+oc get route -n $NAMESPACE -l app.kubernetes.io/component=monitoring
+# Default credentials: admin / changeme
+```
+
+## OpenShift-Specific Challenges and Solutions
+
+### 1. Security Context Constraints
+
+**What:** NIM containers and some infrastructure pods run as specific UIDs by default. OpenShift's `restricted-v2` SCC blocks this by forcing a random UID.
+
+**Error:** `container has runAsNonRoot and image has non-numeric user`
+
+**Services affected:** nim-llm, nim-embedding (NIM Operator managed).
+
+**Fix:** The custom SCC (`wosa-nim`) sets `runAsUser: RunAsAny`, which allows containers to run as the UID defined in their image. The SCC is applied via RoleBinding to the necessary service accounts. It is created declaratively by the Helm chart when `openshift.scc.create: true`.
+
+### 2. GPU Node Tolerations
+
+**What:** GPU nodes carry `NoSchedule` taints. Without matching tolerations, pods stay `Pending`.
+
+**Error:** `0/N nodes are available: N node(s) had untolerated taint`
+
+**Services affected:** nim-llm, nim-embedding (all GPU pods).
+
+**Fix:** Add tolerations in the values overlay for each NIM service:
+
+```yaml
+nimOperator:
+  llm:
+    tolerations:
+      - key: nvidia.com/gpu
+        operator: Exists
+        effect: NoSchedule
+```
+
+Check your taints with `oc describe node <gpu-node> | grep Taints`.
+
+### 3. TOKENIZERS_PARALLELISM Race Condition
+
+**What:** The HuggingFace tokenizers library has a thread pool race condition that can cause NIMs to crash or fail startup probes intermittently.
+
+**Services affected:** nim-llm, nim-embedding.
+
+**Fix:** All NIM Operator env blocks include `TOKENIZERS_PARALLELISM=false` as a preventive measure.
+
+### 4. Hardcoded Connection Parameters
+
+**What:** Several Python scripts hardcode `localhost` for database connections and local file paths for output, which only work in Docker Compose (all services share a network). On Kubernetes/OpenShift, each service runs in a separate pod.
+
+**Services affected:** `advanced_forecasting.py`, `generate_historical_demand.py`, `rapids_gpu_forecasting.py`, `phase3_advanced_forecasting.py`, `rapids_forecasting_agent.py`, `phase1_phase2_forecasting_agent.py`.
+
+**Fix:** Replaced hardcoded values with environment variables (`PGHOST`, `PGPORT`, `FORECAST_OUTPUT_DIR`) while preserving the original defaults for backward compatibility. Note: `phase1_phase2_forecasting_agent.py` uses `DB_HOST`/`DB_PORT` (upstream naming); both are set in the backend deployment template.
+
+### 5. Container Images Require OpenShift Dockerfiles
+
+**What:** The upstream Dockerfiles rely on Docker Compose bind-mounting the entire repository into the container (`volumes: [".:/app"]`). Without bind mounts, images are missing agent configs (`data/config/agents/`), SQL migrations (`data/postgres/`), scripts, and `README.md`. Additionally, `requirements.docker.txt` is missing packages (`tiktoken`, `psycopg`, `pandas`, `nemoguardrails`).
+
+**Services affected:** wosa-backend, wosa-frontend.
+
+**Fix:** Use `Dockerfile.backend-openshift` and `Dockerfile.frontend-openshift` which bundle all required files and dependencies into the image.
+
+## Known Limitations
+
+1. **RAPIDS GPU Forecasting.** The upstream `Dockerfile.rapids` depends on `nvcr.io/nvidia/rapidsai/rapidsai:24.02`, which was removed from NGC. The RAPIDS GPU training path cannot be built. Training works without RAPIDS — the backend automatically falls back to CPU-based scikit-learn models (RandomForest, XGBoost, GradientBoosting). All 38 SKUs train and forecast successfully on CPU.
+
+2. **Milvus GPU Acceleration.** Full GPU support is implemented in the Helm chart (GPU image, CUDA env vars, resource requests, tolerations). However, the upstream codebase never wires it — `gpu_hybrid_retriever.py` exists but no agent imports it. All agents use the CPU `IVF_FLAT` index. The chart supports `milvus.gpu.enabled=true` at deploy time, but it has no effect until upstream imports `gpu_hybrid_retriever`.
+
+3. **Monitoring Dashboard Coverage.** Business-logic Prometheus metrics are defined in `MetricsCollector` but only HTTP middleware metrics are called by the application. Infrastructure panels show real data; business-logic panels (tasks, equipment, safety, environmental) show "No data". Dashboards will display data once the application calls the existing `MetricsCollector` methods.
+
+4. **Nano VL NIM.** The upstream blueprint includes a vision-language NIM (`llama-3.2-nv-nanoVL-1b-v1`) for document processing. The NGC image name contains uppercase letters (`VL`) which violates the OCI image specification (requires lowercase). This makes it incompatible with container runtimes. The Helm chart omits this NIM; document processing falls back to the hosted NVIDIA API via `LLAMA_NANO_VL_URL`.
+
+## Cleanup
+
+```bash
+# Uninstall the Helm release
+helm uninstall wosa -n $NAMESPACE
+
+# NIMCache PVCs persist by default (helm.sh/resource-policy: keep).
+# Delete manually if you want to reclaim storage:
+oc delete nimcache --all -n $NAMESPACE
+oc delete pvc -l app.nvidia.com/nim-cache -n $NAMESPACE
+
+# Delete remaining PVCs
+oc delete pvc -l app.kubernetes.io/instance=wosa -n $NAMESPACE
+```
+
+To remove build resources:
+
+```bash
+oc delete buildconfig wosa-backend wosa-frontend -n $NAMESPACE --ignore-not-found
+oc delete imagestream wosa-backend wosa-frontend -n $NAMESPACE --ignore-not-found
+```
+
+To remove the namespace entirely:
+
+```bash
+oc delete project $NAMESPACE
+```
+
+If monitoring was enabled:
+
+```bash
+oc delete grafanas,grafanadatasources,grafanadashboards --all -n $NAMESPACE --ignore-not-found
+oc delete subscription grafana-operator -n $NAMESPACE --ignore-not-found
+oc get csv -n $NAMESPACE -o name | grep grafana-operator | xargs -r oc delete -n $NAMESPACE --ignore-not-found
+oc delete clusterrolebinding wosa-${NAMESPACE}-grafana-monitoring-view --ignore-not-found
+```

--- a/scripts/data/generate_historical_demand.py
+++ b/scripts/data/generate_historical_demand.py
@@ -163,11 +163,11 @@ class FritoLayDemandGenerator:
         """Initialize database connection"""
         try:
             self.pg_conn = await asyncpg.connect(
-                host="localhost",
-                port=5435,
-                user="warehouse",
+                host=os.getenv("PGHOST", "localhost"),
+                port=int(os.getenv("PGPORT", "5435")),
+                user=os.getenv("POSTGRES_USER", "warehouse"),
                 password=os.getenv("POSTGRES_PASSWORD", ""),
-                database="warehouse"
+                database=os.getenv("POSTGRES_DB", "warehouse")
             )
             logger.info("✅ Connected to PostgreSQL")
         except Exception as e:

--- a/scripts/forecasting/phase1_phase2_forecasting_agent.py
+++ b/scripts/forecasting/phase1_phase2_forecasting_agent.py
@@ -526,8 +526,9 @@ class RAPIDSForecastingAgent:
             results_summary = self._create_forecast_summary(forecasts)
             
             # Save to both root (for runtime) and data/sample/forecasts/ (for reference)
-            output_file = 'phase1_phase2_forecasts.json'
-            sample_file = Path("data/sample/forecasts") / "phase1_phase2_forecasts.json"
+            output_file = os.path.join(os.getenv("FORECAST_OUTPUT_DIR", ""), "phase1_phase2_forecasts.json")
+            sample_dir = Path(os.getenv("FORECAST_OUTPUT_DIR", "data/sample/forecasts"))
+            sample_file = sample_dir / "phase1_phase2_forecasts.json"
             
             self._save_forecast_results(results_summary, output_file, sample_file)
             

--- a/scripts/forecasting/phase3_advanced_forecasting.py
+++ b/scripts/forecasting/phase3_advanced_forecasting.py
@@ -120,11 +120,11 @@ class AdvancedRAPIDSForecastingAgent:
         """Initialize database connection"""
         try:
             self.pg_conn = await asyncpg.connect(
-                host="localhost",
-                port=5435,
-                user="warehouse",
+                host=os.getenv("PGHOST", "localhost"),
+                port=int(os.getenv("PGPORT", "5435")),
+                user=os.getenv("POSTGRES_USER", "warehouse"),
                 password=os.getenv("POSTGRES_PASSWORD", ""),
-                database="warehouse"
+                database=os.getenv("POSTGRES_DB", "warehouse")
             )
             logger.info("✅ Connected to PostgreSQL")
         except Exception as e:
@@ -672,7 +672,7 @@ class AdvancedRAPIDSForecastingAgent:
                     continue
             
             # Save results
-            with open('phase3_advanced_forecasts.json', 'w') as f:
+            with open(os.path.join(os.getenv("FORECAST_OUTPUT_DIR", ""), "phase3_advanced_forecasts.json"), 'w') as f:
                 json.dump(forecasts, f, indent=2, default=str)
             
             logger.info("🎉 Phase 3: Advanced forecasting completed!")

--- a/scripts/forecasting/rapids_forecasting_agent.py
+++ b/scripts/forecasting/rapids_forecasting_agent.py
@@ -107,11 +107,11 @@ class RAPIDSForecastingAgent:
         """Initialize database connection"""
         try:
             self.pg_conn = await asyncpg.connect(
-                host="localhost",
-                port=5435,
-                user="warehouse",
+                host=os.getenv("PGHOST", "localhost"),
+                port=int(os.getenv("PGPORT", "5435")),
+                user=os.getenv("POSTGRES_USER", "warehouse"),
                 password=os.getenv("POSTGRES_PASSWORD", ""),
-                database="warehouse"
+                database=os.getenv("POSTGRES_DB", "warehouse")
             )
             logger.info("✅ Connected to PostgreSQL")
         except Exception as e:

--- a/scripts/forecasting/rapids_gpu_forecasting.py
+++ b/scripts/forecasting/rapids_gpu_forecasting.py
@@ -125,11 +125,11 @@ class RAPIDSForecastingAgent:
         """Initialize database connection"""
         try:
             self.pg_conn = await asyncpg.connect(
-                host="localhost",
-                port=5435,
-                user="warehouse",
+                host=os.getenv("PGHOST", "localhost"),
+                port=int(os.getenv("PGPORT", "5435")),
+                user=os.getenv("POSTGRES_USER", "warehouse"),
                 password=os.getenv("POSTGRES_PASSWORD", ""),
-                database="warehouse"
+                database=os.getenv("POSTGRES_DB", "warehouse")
             )
             logger.info("✅ Database connection established")
         except Exception as e:
@@ -714,12 +714,12 @@ class RAPIDSForecastingAgent:
         from pathlib import Path
         
         # Save to root for runtime use
-        output_file = "rapids_gpu_forecasts.json"
+        output_file = os.path.join(os.getenv("FORECAST_OUTPUT_DIR", ""), "rapids_gpu_forecasts.json")
         async with await anyio.open_file(output_file, 'w') as f:
             await f.write(json.dumps(forecasts, indent=2))
-        
+
         # Also save to data/sample/forecasts/ for reference
-        sample_dir = Path("data/sample/forecasts")
+        sample_dir = Path(os.getenv("FORECAST_OUTPUT_DIR", "data/sample/forecasts"))
         sample_dir.mkdir(parents=True, exist_ok=True)
         sample_file = sample_dir / "rapids_gpu_forecasts.json"
         async with await anyio.open_file(sample_file, 'w') as f:

--- a/src/api/graphs/mcp_integrated_planner_graph.py
+++ b/src/api/graphs/mcp_integrated_planner_graph.py
@@ -34,6 +34,7 @@ from langchain_core.tools import tool
 from dataclasses import asdict
 import logging
 import asyncio
+import os
 import threading
 
 from src.api.services.mcp.tool_discovery import ToolDiscoveryService
@@ -46,11 +47,11 @@ from src.api.utils.log_utils import sanitize_log_data
 logger = logging.getLogger(__name__)
 
 
-# Constants for agent timeouts
+# Agent timeouts (configurable via env vars for self-hosted NIM deployments)
 AGENT_INIT_TIMEOUT = 5.0  # 5 seconds for agent initialization
-AGENT_TIMEOUT_REASONING = 90.0  # 90s for reasoning queries
-AGENT_TIMEOUT_COMPLEX = 50.0  # 50s for complex queries
-AGENT_TIMEOUT_SIMPLE = 45.0  # 45s for simple queries
+AGENT_TIMEOUT_REASONING = float(os.getenv("AGENT_TIMEOUT_REASONING", "90"))
+AGENT_TIMEOUT_COMPLEX = float(os.getenv("AGENT_TIMEOUT_COMPLEX", "50"))
+AGENT_TIMEOUT_SIMPLE = float(os.getenv("AGENT_TIMEOUT_SIMPLE", "45"))
 
 # Constants for complex query detection
 COMPLEX_QUERY_KEYWORDS = [
@@ -1552,8 +1553,7 @@ class MCPPlannerGraph:
                 # Match the timeout in chat.py: 230s for complex, 115s for regular reasoning
                 graph_timeout = 230.0 if is_complex_query else 115.0  # 230s for complex, 115s for regular reasoning
             else:
-                # Regular queries: Match chat.py timeouts (60s for simple, 90s for complex)
-                graph_timeout = 90.0 if is_complex_query else 60.0  # Increased from 30s to 60s for simple queries
+                graph_timeout = float(os.getenv("GRAPH_TIMEOUT_COMPLEX", "90")) if is_complex_query else float(os.getenv("GRAPH_TIMEOUT_SIMPLE", "60"))
             logger.info(f"Graph timeout set to {graph_timeout}s (complex: {is_complex_query}, reasoning: {enable_reasoning})")
             try:
                 result = await asyncio.wait_for(

--- a/src/api/routers/advanced_forecasting.py
+++ b/src/api/routers/advanced_forecasting.py
@@ -139,18 +139,18 @@ class AdvancedForecastingService:
         try:
             # PostgreSQL connection
             self.pg_conn = await asyncpg.connect(
-                host="localhost",
-                port=5435,
-                user="warehouse",
+                host=os.getenv("PGHOST", "localhost"),
+                port=int(os.getenv("PGPORT", "5435")),
+                user=os.getenv("POSTGRES_USER", "warehouse"),
                 password=os.getenv("POSTGRES_PASSWORD", ""),
-                database="warehouse"
+                database=os.getenv("POSTGRES_DB", "warehouse")
             )
             
             # Set db_pool to pg_conn for compatibility with model performance methods
             self.db_pool = self.pg_conn
             
             # Redis connection for caching
-            self.redis_client = redis.Redis(host='localhost', port=6379, db=0)
+            self.redis_client = redis.Redis(host=os.getenv('REDIS_HOST','localhost'), port=int(os.getenv('REDIS_PORT','6379')), db=0)
             
             logger.info("✅ Advanced forecasting service initialized")
         except Exception as e:

--- a/src/api/routers/chat.py
+++ b/src/api/routers/chat.py
@@ -18,6 +18,7 @@ from pydantic import BaseModel
 from typing import Optional, Dict, Any, List, Union
 import logging
 import asyncio
+import os
 import re
 import time
 from src.api.graphs.mcp_integrated_planner_graph import get_mcp_planner_graph
@@ -716,10 +717,7 @@ async def chat(req: ChatRequest):
             # For non-complex reasoning queries, set to 115s (slightly less than frontend 120s)
             MAIN_QUERY_TIMEOUT = 230 if is_complex_query else 115  # 230s for complex, 115s for regular reasoning
         else:
-            # Regular queries: Increased timeouts to prevent premature timeouts
-            # Simple queries: 60s (was 30s) - allows time for LLM processing
-            # Complex queries: 90s (was 60s) - allows time for complex analysis
-            MAIN_QUERY_TIMEOUT = 90 if is_complex_query else 60
+            MAIN_QUERY_TIMEOUT = int(os.getenv("CHAT_TIMEOUT_COMPLEX", "90")) if is_complex_query else int(os.getenv("CHAT_TIMEOUT_SIMPLE", "60"))
         
         # Initialize result to None to avoid UnboundLocalError
         result = None


### PR DESCRIPTION
## Description

This PR adds full Red Hat OpenShift deployment support for the Multi-Agent Intelligent Warehouse Blueprint, validated end-to-end on an OpenShift cluster with the NIM Operator. The deployment includes self-hosted LLM and embedding inference, demo data seeding, demand history generation, and Grafana monitoring dashboards. The entire deployment is declarative via Helm with no external scripts required.

## What's Included

**Helm Chart**
- `Chart.yaml` defines all platform services (backend, frontend, nginx, TimescaleDB, Redis, Milvus, Etcd, MinIO, and Kafka) as a single deployable unit.
- `_helpers.tpl` introduces reusable Helm helpers for consistent naming, labeling, image pull secrets, and OpenShift-compatible security contexts.
- `values.yaml` extends the base configuration with OpenShift and NIM Operator settings (disabled by default).
- `values-openshift.yaml` enables OpenShift-specific features, NIM Operator integration, internal registry image paths, configurable timeout settings for self-hosted NIM inference, and NIMCache profile filtering to avoid downloading unnecessary model variants.

**OpenShift Templates**
- `openshift-route.yaml` - Route with edge TLS termination through nginx and configurable timeout annotations for long-running LLM requests.
- `openshift-scc.yaml` - custom SCC that allows NIM workloads to run correctly on OpenShift, prevents SELinux relabeling on large model PVCs, and grants access to all required service accounts.
- `nim-llm.yaml` and `nim-embedding.yaml` - NIMCache + NIMService pairs for LLM and embedding models, gated by `.Capabilities.APIVersions.Has` so they render only when the NIM Operator is installed.
- `secrets.yaml` - application secrets, NGC image pull secrets, and NGC API key secrets required for NIM Operator authentication.
- `networkpolicy.yaml` - default-deny networking with explicit ingress, internal service communication, monitoring, DNS, and external HTTPS access rules.

**Application Deployments**
- `backend-deployment.yaml` - backend deployment updated for OpenShift compatibility, dynamic NIM service discovery, environment-driven configuration, and restricted-v2 security requirements.
- `frontend-deployment.yaml` - React frontend deployment served by `nginx-unprivileged`.
- `nginx-deployment.yaml` and `configmaps.yaml` - reverse proxy with API routing, WebSockets, and extended inference timeouts.
- Infrastructure deployments (`TimescaleDB`, `Redis`, `Milvus`, `Etcd`, `MinIO`, and `Kafka`) updated with PVC-backed storage, health checks, and metrics exporters where applicable.
- `pvcs.yaml` provides persistent storage definitions for all stateful services.
- `serviceaccount.yaml` creates dedicated service accounts with conditional NGC pull secret support.

**Helm Hook Jobs**
- `db-init-job.yaml` initializes and upgrades the database schema.
- `user-init-job.yaml` creates default application users.
- `demo-data-job.yaml` seeds inventory, task, telemetry, and safety incident data.
- `demo-demand-job.yaml` generates historical demand records for forecasting demonstrations.

**Monitoring Stack**
- Optional monitoring support enabled via `monitoring.enabled=true`.
- ServiceMonitors for backend, TimescaleDB, Redis, and Milvus metrics.
- Prometheus alert rules and Alertmanager configuration.
- Namespace-scoped Grafana deployment with preconfigured Overview, Operations, and Safety & Compliance dashboards using OpenShift Thanos Querier as the data source.

**OpenShift Dockerfiles**
- `Dockerfile.backend-openshift` fixes upstream image build issues, includes all required runtime files, and remains compatible with OpenShift's random UID model.
- `Dockerfile.frontend-openshift` replaces the development server with a production nginx-unprivileged deployment.

**Source Code Compatibility**
- Replaced hardcoded localhost database and Redis connections with environment-driven configuration while preserving existing defaults.
- Added configurable forecast output locations via `FORECAST_OUTPUT_DIR`.
- Converted agent, graph, and chat timeout constants into configurable environment variables to support higher-latency self-hosted NIM inference.
- Updated `.dockerignore` to include files required by OpenShift image builds.

**Documentation**
- `docs/deployment/openshift-deployment.md` - complete deployment runbook covering prerequisites, NIM Operator setup, image builds, deployment, monitoring, troubleshooting, and cleanup.
- `README.md` - adds a link to the OpenShift deployment guide.

### How it works

Users deploy the entire platform with a single command. Secrets, Routes, SCC grants, NIM Operator resources, initialization jobs, and optional monitoring components are all managed by the Helm chart:

```bash
helm install wosa deploy/helm/wosa \
  -n wosa --create-namespace \
  -f deploy/helm/wosa/values-openshift.yaml \
  --set openshift.ngcSecret.password="$NVIDIA_API_KEY" \
  --set demoData.enabled=true \
  --set demoDemand.enabled=true \
  --set monitoring.enabled=true \
  --timeout 45m
```