### PR TITLE
fix: add missing chat error response helper

### DIFF
--- a/src/api/routers/chat.py
+++ b/src/api/routers/chat.py
@@ -517,6 +517,34 @@ def _create_fallback_chat_response(
     )
 
 
+def _create_error_chat_response(
+    user_message: str,
+    error_message: str,
+    error_type: str,
+    session_id: str,
+    confidence: float,
+) -> ChatResponse:
+    """Create a standardized ChatResponse for handled chat errors."""
+    suggestions = [
+        "Try rephrasing your question",
+        "Try again in a moment",
+        "Contact support if the issue persists",
+    ]
+    return ChatResponse(
+        reply=user_message,
+        route="error",
+        intent="error",
+        session_id=session_id,
+        context={
+            "error": error_message,
+            "error_type": error_type,
+            "suggestions": suggestions,
+        },
+        confidence=confidence,
+        recommendations=suggestions,
+    )
+
+
 def _create_safety_violation_response(
     violations: List[str],
     confidence: float,

--- a/tests/unit/test_chat_router_private_helpers.py
+++ b/tests/unit/test_chat_router_private_helpers.py
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Regression tests for chat router private helper wiring."""
+
+import ast
+import unittest
+from pathlib import Path
+
+
+CHAT_ROUTER_PATH = Path(__file__).resolve().parents[2] / "src" / "api" / "routers" / "chat.py"
+
+
+class ChatRouterPrivateHelperTests(unittest.TestCase):
+    def test_called_create_helpers_are_defined(self) -> None:
+        """Ensure refactors do not leave runtime-only missing helper errors behind."""
+        tree = ast.parse(CHAT_ROUTER_PATH.read_text())
+        defined_helpers = set()
+        called_helpers = set()
+
+        for node in ast.walk(tree):
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name.startswith("_create_"):
+                defined_helpers.add(node.name)
+            elif isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id.startswith("_create_"):
+                called_helpers.add(node.func.id)
+
+        self.assertLessEqual(called_helpers, defined_helpers)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add the missing `_create_error_chat_response` helper used by chat error paths
- Add regression coverage that checks locally-called `_create_*` helpers in `chat.py` are defined

## Verification
- `python3 -m py_compile src/api/routers/chat.py tests/unit/test_chat_router_private_helpers.py`
- `python3 -m unittest tests.unit.test_chat_router_private_helpers -v`
- `git diff --check`

Closes #30