### PR TITLE
ci: publish container images

### DIFF
--- a/.github/workflows/container-images.yml
+++ b/.github/workflows/container-images.yml
@@ -1,0 +1,97 @@
+name: Container Images
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  build:
+    name: Build ${{ matrix.name }} image
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: warehouse-assistant
+            dockerfile: Dockerfile
+            description: Combined backend API and built frontend runtime image
+          - name: warehouse-assistant-backend
+            dockerfile: Dockerfile.backend
+            description: Backend API runtime image
+          - name: warehouse-assistant-frontend
+            dockerfile: Dockerfile.frontend
+            description: Frontend development server image
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set image metadata
+        id: image
+        shell: bash
+        run: |
+          owner="${GITHUB_REPOSITORY_OWNER,,}"
+          repo="${GITHUB_REPOSITORY#*/}"
+          repo="${repo,,}"
+          image="${REGISTRY}/${owner}/${repo}-${{ matrix.name }}"
+
+          echo "image=${image}" >> "$GITHUB_OUTPUT"
+          echo "version=${GITHUB_SHA::12}" >> "$GITHUB_OUTPUT"
+          echo "created=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ steps.image.outputs.image }}
+          labels: |
+            org.opencontainers.image.title=${{ matrix.name }}
+            org.opencontainers.image.description=${{ matrix.description }}
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.created=${{ steps.image.outputs.created }}
+          tags: |
+            type=sha,prefix=sha-,format=short
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and publish image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          push: ${{ github.event_name != 'pull_request' }}
+          build-args: |
+            VERSION=${{ steps.image.outputs.version }}
+            GIT_SHA=${{ github.sha }}
+            BUILD_TIME=${{ steps.image.outputs.created }}
+          labels: ${{ steps.meta.outputs.labels }}
+          tags: ${{ steps.meta.outputs.tags }}
+          cache-from: type=gha,scope=${{ matrix.name }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.name }}


### PR DESCRIPTION
## Summary
- Add a GitHub Actions workflow to build container images for the combined app, backend, and frontend Dockerfiles.
- Publish images to GHCR on pushes to main.
- Build images without pushing on pull requests for validation.
- Tag published images with sha-<short-sha> and latest on the default branch.

## Images
- ghcr.io/<owner>/<repo>-warehouse-assistant
- ghcr.io/<owner>/<repo>-warehouse-assistant-backend
- ghcr.io/<owner>/<repo>-warehouse-assistant-frontend

## Test Plan
- Parsed .github/workflows/container-images.yml with PyYAML.
- Ran git diff --check.
- Built all three images locally with docker buildx:
  - Dockerfile
  - Dockerfile.backend
  - Dockerfile.frontend

## Notes
This is the image-publishing prerequisite for a future Helm chart.