### PR TITLE
Fix backend agent configuration packaging

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -76,6 +76,8 @@ COPY --from=backend-deps /usr/local/bin /usr/local/bin
 COPY src/ ./src/
 # Copy guardrails configuration (required for NeMo Guardrails)
 COPY data/config/guardrails/ ./data/config/guardrails/
+# Copy agent personas and prompts loaded by the backend at runtime.
+COPY data/config/agents/ ./data/config/agents/
 
 # Build arguments for version injection
 ARG VERSION=0.0.0

--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -45,6 +45,8 @@ COPY --from=backend-deps /usr/local/bin /usr/local/bin
 COPY src/ ./src/
 # Copy guardrails configuration (required for NeMo Guardrails)
 COPY data/config/guardrails/ ./data/config/guardrails/
+# Copy agent personas and prompts loaded by the backend at runtime.
+COPY data/config/agents/ ./data/config/agents/
 # Copy setup/data utilities used by Brev staging actions.
 RUN mkdir -p ./scripts/setup ./scripts/data
 COPY scripts/setup/create_default_users.py ./scripts/setup/create_default_users.py

--- a/src/api/services/agent_config.py
+++ b/src/api/services/agent_config.py
@@ -28,6 +28,8 @@ from dataclasses import dataclass, field
 
 logger = logging.getLogger(__name__)
 
+_DEFAULT_CONFIG_DIR = Path(__file__).resolve().parents[3] / "data" / "config" / "agents"
+
 
 @dataclass
 class AgentPersona:
@@ -63,26 +65,11 @@ class AgentConfigLoader:
             config_dir: Directory containing agent config files. 
                        Defaults to data/config/agents/ relative to project root.
         """
-        if config_dir is None:
-            # Find project root (look for pyproject.toml or README.md)
-            current = Path(__file__).resolve()
-            project_root = None
-            for parent in [current] + list(current.parents):
-                if (parent / "pyproject.toml").exists() or (parent / "README.md").exists():
-                    project_root = parent
-                    break
-            
-            if project_root is None:
-                raise ValueError("Could not find project root directory")
-            
-            config_dir = project_root / "data" / "config" / "agents"
-        
-        self.config_dir = Path(config_dir)
+        self.config_dir = config_dir or _DEFAULT_CONFIG_DIR
         self._cache: Dict[str, AgentConfig] = {}
-        
-        if not self.config_dir.exists():
-            logger.warning(f"Agent config directory does not exist: {self.config_dir}")
-            self.config_dir.mkdir(parents=True, exist_ok=True)
+
+        if not self.config_dir.is_dir():
+            raise FileNotFoundError(f"Agent config directory does not exist: {self.config_dir}")
     
     def load_agent_config(self, agent_name: str) -> AgentConfig:
         """
@@ -208,4 +195,3 @@ def load_agent_config(agent_name: str) -> AgentConfig:
         AgentConfig object
     """
     return get_agent_config_loader().load_agent_config(agent_name)
-

--- a/tests/unit/test_agent_config.py
+++ b/tests/unit/test_agent_config.py
@@ -1,0 +1,22 @@
+"""Tests for loading agent configuration files."""
+
+from pathlib import Path
+
+import pytest
+
+from src.api.services.agent_config import AgentConfigLoader
+
+
+def test_default_config_directory_loads_agent() -> None:
+    """Load an agent from the repository-relative default directory."""
+    config = AgentConfigLoader().load_agent_config("safety")
+
+    assert config.name == "Safety & Compliance Agent"
+
+
+def test_missing_config_directory_fails_fast(tmp_path: Path) -> None:
+    """Reject a runtime image that omits agent configuration files."""
+    missing_config_dir = tmp_path / "agents"
+
+    with pytest.raises(FileNotFoundError, match="Agent config directory does not exist"):
+        AgentConfigLoader(missing_config_dir)


### PR DESCRIPTION
## Summary

- package agent persona YAML files in both backend runtime images
- resolve the default agent config directory deterministically from the application layout
- fail fast when the runtime image omits agent configuration
- add focused loader tests

## Root cause

The backend image copied src/ and guardrail configuration, but omitted data/config/agents. The loader also searched for pyproject.toml or README.md, neither of which exists in the runtime image, so chat requests failed with: Could not find project root directory.

## Validation

- focused agent-config tests: 2 passed
- Ruff checks passed
- Docker build checks passed for Dockerfile and Dockerfile.backend
- git diff check passed