### PR TITLE
Fix Brev compatibility with Docker Compose 2.29

### DIFF
--- a/deploy/brev/docker-compose.maiw.yaml
+++ b/deploy/brev/docker-compose.maiw.yaml
@@ -132,7 +132,13 @@ services:
             CUDA_VISIBLE_DEVICES: ${CUDA_VISIBLE_DEVICES:-0,1,2,3}
             NVIDIA_VISIBLE_DEVICES: all
             NVIDIA_DRIVER_CAPABILITIES: compute,utility
-        gpus: all
+        deploy:
+            resources:
+                reservations:
+                    devices:
+                        - driver: nvidia
+                          count: all
+                          capabilities: [gpu]
         ipc: host
         ulimits:
             memlock: -1

--- a/deploy/brev/startup.sh
+++ b/deploy/brev/startup.sh
@@ -313,7 +313,6 @@ echo "Starting the blueprint..."
 compose up \
   -d \
   --quiet-pull \
-  --quiet-build \
   --remove-orphans \
   --wait
 


### PR DESCRIPTION
## What changed

- Replace the Compose 2.30-only `gpus: all` field with GPU device reservations supported by Compose 2.29.
- Remove the unsupported `docker compose up --quiet-build` option. Images are already built in the preceding step.

## Why

A Brev cloud-vendor change provisioned Docker Compose v2.29.7. Its schema rejected `services.llm-nim.gpus`, preventing image pulls and deployment startup.

## Impact

Brev deployments using Compose 2.29 can parse the stack and allocate all NVIDIA GPUs while remaining compatible with newer Compose releases.

## Validation

- `docker compose v2.29.7 ... config --quiet`
- `bash -n deploy/brev/startup.sh`
- `git diff --check`
- Live staging advanced through image pulls, builds, database initialization, and service startup. NIM readiness remains separately blocked by the selected vendor host's NVIDIA 565 driver; NIM 2.0.6 requires driver 580 or later.
