### PR TITLE
fix: share the tool-discovery registry, plus four silent-failure bugs

### DIFF
--- a/data/postgres/000_schema.sql
+++ b/data/postgres/000_schema.sql
@@ -83,7 +83,7 @@ CREATE TABLE IF NOT EXISTS audit_log (
 
 DO $$
 BEGIN
-  IF NOT EXISTS (SELECT 1 FROM pg_extension WHERE extname=timescaledb) THEN
+  IF NOT EXISTS (SELECT 1 FROM pg_extension WHERE extname='timescaledb') THEN
     CREATE EXTENSION IF NOT EXISTS timescaledb;
   END IF;
 EXCEPTION WHEN OTHERS THEN NULL;
@@ -91,7 +91,7 @@ END $$;
 
 DO $$
 BEGIN
-  PERFORM create_hypertable(equipment_telemetry,ts, if_not_exists=>TRUE);
+  PERFORM create_hypertable('equipment_telemetry','ts', if_not_exists=>TRUE);
 EXCEPTION WHEN OTHERS THEN NULL;
 END $$;
 

--- a/data/postgres/001_equipment_schema.sql
+++ b/data/postgres/001_equipment_schema.sql
@@ -39,7 +39,7 @@ CREATE TABLE IF NOT EXISTS equipment_telemetry (
 -- Create Timescale hypertable for telemetry
 DO $$
 BEGIN
-  IF NOT EXISTS (SELECT 1 FROM pg_extension WHERE extname=timescaledb) THEN
+  IF NOT EXISTS (SELECT 1 FROM pg_extension WHERE extname='timescaledb') THEN
     CREATE EXTENSION IF NOT EXISTS timescaledb;
   END IF;
 EXCEPTION WHEN OTHERS THEN NULL;

--- a/scripts/start_server.sh
+++ b/scripts/start_server.sh
@@ -30,12 +30,23 @@ fi
 # Set default port if not set
 PORT=${PORT:-8001}
 
-# Check if port is already in use
+# Check if port is already in use.
+#
+# This previously ran `lsof -ti:$PORT | xargs kill -9` unconditionally, which
+# SIGKILLs whatever owns the port -- not necessarily a previous run of this
+# server. On a developer machine port 8001 is commonly held by an unrelated
+# service, and that process was destroyed without warning or confirmation.
+# Refuse to start instead, and tell the user how to proceed.
 if lsof -Pi :$PORT -sTCP:LISTEN -t >/dev/null 2>&1; then
-    echo "⚠️  Port $PORT is already in use"
-    echo "   Stopping existing process..."
-    lsof -ti:$PORT | xargs kill -9 2>/dev/null || true
-    sleep 2
+    OWNER_PID=$(lsof -ti:$PORT | head -1)
+    OWNER_CMD=$(ps -p "$OWNER_PID" -o comm= 2>/dev/null || echo "unknown")
+    echo "❌ Port $PORT is already in use by PID $OWNER_PID ($OWNER_CMD)"
+    echo ""
+    echo "   This script will not kill it -- it may not belong to this project."
+    echo "   Either:"
+    echo "     • run on another port:  PORT=8011 $0"
+    echo "     • or stop it yourself:  kill $OWNER_PID"
+    exit 1
 fi
 
 echo "🚀 Starting Warehouse Operational Assistant API server..."

--- a/src/api/agents/document/mcp_document_agent.py
+++ b/src/api/agents/document/mcp_document_agent.py
@@ -31,7 +31,8 @@ from src.api.services.mcp.tool_discovery import (
     ToolDiscoveryService,
     DiscoveredTool,
     ToolCategory,
-)
+
+    get_tool_discovery_service,)
 from src.api.services.mcp.base import MCPManager
 from src.api.services.reasoning import (
     get_reasoning_engine,
@@ -135,7 +136,7 @@ class MCPDocumentExtractionAgent:
 
             # Initialize MCP components
             self.mcp_manager = MCPManager()
-            self.tool_discovery = ToolDiscoveryService()
+            self.tool_discovery = get_tool_discovery_service()
 
             # Start tool discovery
             await self.tool_discovery.start_discovery()

--- a/src/api/agents/forecasting/forecasting_agent.py
+++ b/src/api/agents/forecasting/forecasting_agent.py
@@ -33,7 +33,8 @@ from src.api.services.mcp.tool_discovery import (
     ToolDiscoveryService,
     DiscoveredTool,
     ToolCategory,
-)
+
+    get_tool_discovery_service,)
 from src.api.services.mcp.base import MCPManager
 from src.api.services.reasoning import (
     get_reasoning_engine,
@@ -111,7 +112,7 @@ class ForecastingAgent:
 
             # Initialize MCP components
             self.mcp_manager = MCPManager()
-            self.tool_discovery = ToolDiscoveryService()
+            self.tool_discovery = get_tool_discovery_service()
 
             # Start tool discovery
             await self.tool_discovery.start_discovery()

--- a/src/api/agents/inventory/mcp_equipment_agent.py
+++ b/src/api/agents/inventory/mcp_equipment_agent.py
@@ -35,6 +35,7 @@ from src.api.services.mcp.tool_discovery import (
     ToolDiscoveryService,
     DiscoveredTool,
     ToolCategory,
+    get_tool_discovery_service,
 )
 from src.api.services.mcp.base import MCPManager
 
@@ -123,7 +124,7 @@ class MCPEquipmentAssetOperationsAgent:
 
             # Initialize MCP components
             self.mcp_manager = MCPManager()
-            self.tool_discovery = ToolDiscoveryService()
+            self.tool_discovery = get_tool_discovery_service()
 
             # Start tool discovery
             await self.tool_discovery.start_discovery()

--- a/src/api/agents/operations/mcp_operations_agent.py
+++ b/src/api/agents/operations/mcp_operations_agent.py
@@ -34,7 +34,8 @@ from src.api.services.mcp.tool_discovery import (
     ToolDiscoveryService,
     DiscoveredTool,
     ToolCategory,
-)
+
+    get_tool_discovery_service,)
 from src.api.services.mcp.base import MCPManager
 from src.api.services.reasoning import (
     get_reasoning_engine,
@@ -113,7 +114,7 @@ class MCPOperationsCoordinationAgent:
 
             # Initialize MCP components
             self.mcp_manager = MCPManager()
-            self.tool_discovery = ToolDiscoveryService()
+            self.tool_discovery = get_tool_discovery_service()
 
             # Start tool discovery
             await self.tool_discovery.start_discovery()

--- a/src/api/agents/safety/mcp_safety_agent.py
+++ b/src/api/agents/safety/mcp_safety_agent.py
@@ -35,6 +35,7 @@ from src.api.services.mcp.tool_discovery import (
     ToolDiscoveryService,
     DiscoveredTool,
     ToolCategory,
+    get_tool_discovery_service,
 )
 from src.api.services.mcp.base import MCPManager
 from src.api.services.reasoning import (
@@ -114,7 +115,7 @@ class MCPSafetyComplianceAgent:
 
             # Initialize MCP components
             self.mcp_manager = MCPManager()
-            self.tool_discovery = ToolDiscoveryService()
+            self.tool_discovery = get_tool_discovery_service()
 
             # Start tool discovery
             await self.tool_discovery.start_discovery()

--- a/src/api/graphs/mcp_integrated_planner_graph.py
+++ b/src/api/graphs/mcp_integrated_planner_graph.py
@@ -36,7 +36,7 @@ import logging
 import asyncio
 import threading
 
-from src.api.services.mcp.tool_discovery import ToolDiscoveryService
+from src.api.services.mcp.tool_discovery import ToolDiscoveryService, get_tool_discovery_service
 from src.api.services.mcp.tool_binding import ToolBindingService
 from src.api.services.mcp.tool_routing import ToolRoutingService, RoutingStrategy
 from src.api.services.mcp.tool_validation import ToolValidationService
@@ -623,7 +623,7 @@ class MCPPlannerGraph:
         """Initialize MCP components and create the graph."""
         try:
             # Initialize MCP services (simplified for Phase 2 Step 3)
-            self.tool_discovery = ToolDiscoveryService()
+            self.tool_discovery = get_tool_discovery_service()
             self.tool_binding = ToolBindingService(self.tool_discovery)
             # Skip complex routing for now - will implement in next step
             self.tool_routing = None

--- a/src/api/graphs/mcp_planner_graph.py
+++ b/src/api/graphs/mcp_planner_graph.py
@@ -34,6 +34,7 @@ from dataclasses import asdict
 
 from src.api.services.mcp import (
     ToolDiscoveryService,
+    get_tool_discovery_service,
     ToolBindingService,
     ToolRoutingService,
     ToolValidationService,
@@ -347,7 +348,7 @@ class MCPPlannerGraph:
         """Initialize MCP components and create the graph."""
         try:
             # Initialize MCP services (simplified for Phase 2 Step 1)
-            self.tool_discovery = ToolDiscoveryService()
+            self.tool_discovery = get_tool_discovery_service()
             self.tool_binding = ToolBindingService(self.tool_discovery)
             # Skip complex routing for now - will implement in next step
             self.tool_routing = None

--- a/src/api/routers/chat.py
+++ b/src/api/routers/chat.py
@@ -517,6 +517,34 @@ def _create_fallback_chat_response(
     )
 
 
+def _create_error_chat_response(
+    user_message: str,
+    error_message: str,
+    error_type: str,
+    session_id: str,
+    confidence: float = 0.0,
+) -> ChatResponse:
+    """Create a ChatResponse for an unrecoverable error.
+
+    Two call sites (the generic error handler and the asyncio.TimeoutError
+    handler) already invoked this helper, but it was never defined -- so the
+    error path itself raised `NameError: name '_create_error_chat_response' is
+    not defined` and the request returned HTTP 500 instead of the intended
+    graceful message.
+
+    The technical detail is surfaced in structured_data rather than in `reply`,
+    so users see the friendly text while clients can still inspect the cause.
+    """
+    return ChatResponse(
+        reply=user_message,
+        route="error",
+        intent="error",
+        session_id=session_id,
+        confidence=confidence,
+        structured_data={"error": error_type, "message": error_message},
+    )
+
+
 def _create_safety_violation_response(
     violations: List[str],
     confidence: float,

--- a/src/api/routers/mcp.py
+++ b/src/api/routers/mcp.py
@@ -24,7 +24,7 @@ import logging
 import asyncio
 
 from src.api.graphs.mcp_integrated_planner_graph import get_mcp_planner_graph
-from src.api.services.mcp.tool_discovery import ToolDiscoveryService
+from src.api.services.mcp.tool_discovery import ToolDiscoveryService, get_tool_discovery_service
 from src.api.services.mcp.tool_binding import ToolBindingService
 from src.api.services.mcp.tool_routing import ToolRoutingService, RoutingStrategy
 from src.api.services.mcp.tool_validation import ToolValidationService
@@ -45,7 +45,7 @@ async def get_mcp_services():
     if _mcp_services is None:
         try:
             # Initialize MCP services (simplified for testing)
-            tool_discovery = ToolDiscoveryService()
+            tool_discovery = get_tool_discovery_service()
             tool_binding = ToolBindingService(tool_discovery)
             # Skip complex routing for now - will implement in next step
             tool_routing = None

--- a/src/api/services/evidence/evidence_collector.py
+++ b/src/api/services/evidence/evidence_collector.py
@@ -32,7 +32,7 @@ import json
 from src.api.services.llm.nim_client import get_nim_client, LLMResponse
 from src.retrieval.hybrid_retriever import get_hybrid_retriever, SearchContext
 from src.memory.memory_manager import get_memory_manager
-from src.api.services.mcp.tool_discovery import ToolDiscoveryService, ToolCategory
+from src.api.services.mcp.tool_discovery import ToolDiscoveryService, ToolCategory, get_tool_discovery_service
 
 logger = logging.getLogger(__name__)
 
@@ -132,7 +132,7 @@ class EvidenceCollector:
             self.nim_client = await get_nim_client()
             self.hybrid_retriever = await get_hybrid_retriever()
             self.memory_manager = await get_memory_manager()
-            self.tool_discovery = ToolDiscoveryService()
+            self.tool_discovery = get_tool_discovery_service()
             await self.tool_discovery.start_discovery()
 
             logger.info("Evidence Collector initialized successfully")

--- a/src/api/services/mcp/__init__.py
+++ b/src/api/services/mcp/__init__.py
@@ -44,7 +44,12 @@ from .base import (
     AdapterType,
     ToolCategory,
 )
-from .tool_discovery import ToolDiscoveryService, DiscoveredTool, ToolDiscoveryConfig
+from .tool_discovery import (
+    ToolDiscoveryService,
+    DiscoveredTool,
+    ToolDiscoveryConfig,
+    get_tool_discovery_service,
+)
 from .tool_binding import (
     ToolBindingService,
     ToolBinding,
@@ -97,6 +102,7 @@ __all__ = [
     "ToolCategory",
     # Tool Discovery
     "ToolDiscoveryService",
+    "get_tool_discovery_service",
     "DiscoveredTool",
     "ToolDiscoveryConfig",
     # Tool Binding

--- a/src/api/services/mcp/tool_discovery.py
+++ b/src/api/services/mcp/tool_discovery.py
@@ -23,6 +23,8 @@ tools from various MCP servers and adapters.
 
 import asyncio
 import logging
+import threading
+import weakref
 from typing import Dict, List, Any, Optional, Set, Callable
 from dataclasses import dataclass, field
 from enum import Enum
@@ -372,7 +374,24 @@ class ToolDiscoveryService:
 
     async def _register_discovered_tool(self, tool: DiscoveredTool) -> None:
         """Register a discovered tool with security validation."""
+        # `tool_id` defaults to a fresh uuid4 per DiscoveredTool construction, and
+        # _discover_from_mcp_adapter rebuilds these every cycle -- so the registry
+        # gained a duplicate entry on every 30s discovery pass (the update-in-place
+        # branch below could never match), which _cleanup_old_data then reaped 300s
+        # later: the observed "Cleaned up N old tools" churn.
+        #
+        # Make the id DETERMINISTIC from (source, name) rather than re-keying the
+        # dict: tool_binding, tool_routing and tool_validation all look tools up via
+        # `discovered_tools.get(<tool_id>)`, so the dict must stay keyed by tool_id.
+        tool.tool_id = f"{tool.source}:{tool.name}"
         tool_key = tool.tool_id
+
+        # Preserve usage across re-discovery -- _cleanup_old_data only evicts
+        # entries whose usage_count is still 0.
+        existing = self.discovered_tools.get(tool_key)
+        if existing is not None:
+            tool.usage_count = existing.usage_count
+            tool.last_used = existing.last_used
 
         # Security check: Validate tool before registration
         try:
@@ -837,3 +856,61 @@ class ToolDiscoveryService:
                 cat.value: len(tools) for cat, tools in self.tool_categories.items()
             },
         }
+
+
+# ---------------------------------------------------------------------------
+# Shared service accessor
+#
+# BUG CONTEXT (2026-07-28): nine call sites each did `ToolDiscoveryService()`,
+# giving nine independent registries plus nine 30s discovery loops and nine 300s
+# cleanup loops. The planner graph's instance had zero sources registered, so it
+# reported "Retrieved 0 available tools" while the equipment agent's instance
+# held 4 -- and agents that needed the tool list stalled to their 45s timeout.
+#
+# Direct construction stays supported (tests and deliberate isolation rely on
+# it); this accessor is the path production code should use.
+# ---------------------------------------------------------------------------
+
+# Keyed by event loop rather than a single module global: this service owns
+# background tasks (_discovery_loop, _cleanup_loop) that bind to the loop running
+# when start_discovery() is called. A plain global created under one loop and
+# reused under another (uvicorn --reload, test suites) yields tasks attached to a
+# dead loop -- silent, and worse than the bug being fixed. WeakKeyDictionary lets
+# entries drop when a loop is collected, so ids are never reused.
+_shared_services: "weakref.WeakKeyDictionary" = weakref.WeakKeyDictionary()
+_shared_service_no_loop: Optional["ToolDiscoveryService"] = None
+_shared_service_lock = threading.Lock()
+
+
+def get_tool_discovery_service(
+    config: ToolDiscoveryConfig = None,
+) -> "ToolDiscoveryService":
+    """Return the shared ToolDiscoveryService for the current event loop.
+
+    All production consumers (agents, planner graphs, the MCP router, the
+    evidence collector) must go through this so they observe one registry.
+    Constructing ToolDiscoveryService() directly is still valid for tests and
+    deliberate isolation.
+
+    `config` applies only when the instance is first created; it is ignored on
+    subsequent calls, so callers cannot silently reconfigure a live service that
+    other consumers already depend on.
+    """
+    global _shared_service_no_loop
+
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        loop = None
+
+    with _shared_service_lock:
+        if loop is None:
+            if _shared_service_no_loop is None:
+                _shared_service_no_loop = ToolDiscoveryService(config)
+            return _shared_service_no_loop
+
+        service = _shared_services.get(loop)
+        if service is None:
+            service = ToolDiscoveryService(config)
+            _shared_services[loop] = service
+        return service

--- a/src/api/services/monitoring/performance_monitor.py
+++ b/src/api/services/monitoring/performance_monitor.py
@@ -369,8 +369,14 @@ class PerformanceMonitor:
             m for m in self.metrics
             if m.name == "timeout_occurred" and m.timestamp.timestamp() >= cutoff_time
         ]
-        if timeout_metrics and len(recent_requests) > 0:
-            timeout_rate = len(timeout_metrics) / len(recent_requests)
+        # `recent_requests` is local to get_performance_stats(); referencing it here
+        # raised `NameError: name 'recent_requests' is not defined` on EVERY alert
+        # check, so the timeout-rate alert never fired and the alert loop logged an
+        # error each cycle. `stats` is already in scope above and carries the same
+        # count for the requested window.
+        total_requests = stats.get("total_requests", 0)
+        if timeout_metrics and total_requests > 0:
+            timeout_rate = len(timeout_metrics) / total_requests
             if timeout_rate > 0.10:  # 10% timeout rate
                 # Group timeouts by location
                 timeout_locations = defaultdict(int)

--- a/tests/test_tool_discovery_shared_registry.py
+++ b/tests/test_tool_discovery_shared_registry.py
@@ -1,0 +1,147 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Regression tests for the tool-discovery registry fragmentation bug.
+
+Observed failure (2026-07-28, local deployment):
+    Nine separate `ToolDiscoveryService()` instances are constructed across the
+    codebase (5 agents, 2 planner graphs, the MCP router, the evidence
+    collector). Each keeps its own `discovered_tools` dict plus its own 30s
+    discovery loop and 300s cleanup loop, so a source registered by one agent is
+    invisible to every other consumer.
+
+    The planner graph builds its own instance and registers no adapters into it,
+    so `get_available_tools()` returns 0 and the equipment/safety agents stall
+    until their 45s budget expires and emit
+    "The system is taking longer than expected to process it."
+
+    Log signature (same request, interleaved, different objects):
+        Tool discovery completed: 0 tools discovered from 0 sources
+        Tool discovery completed: 4 tools discovered from 1 sources
+
+These tests pin the *contract* we want: all consumers share one registry, and a
+tool registered anywhere is discoverable everywhere.
+"""
+
+import asyncio
+from types import SimpleNamespace
+
+from src.api.services.mcp.tool_discovery import ToolDiscoveryService
+
+
+class _FakeTool:
+    """Stand-in for an MCP tool.
+
+    Must satisfy every attribute `_discover_from_mcp_adapter` touches --
+    name/description/parameters/tool_type.value/handler -- because that method
+    swallows AttributeError into a log line and returns 0 tools, which would
+    make a shape mismatch look identical to the fragmentation bug.
+    """
+
+    def __init__(self, name):
+        self.name = name
+        self.description = f"fake tool {name}"
+        self.parameters = {}
+        self.tool_type = SimpleNamespace(value="function")
+        self.handler = lambda **kw: None
+
+
+class _FakeAdapter:
+    """Minimal stand-in for an MCP adapter (mirrors EquipmentMCPAdapter shape)."""
+
+    def __init__(self, names):
+        self.tools = {n: _FakeTool(n) for n in names}
+        self.config = SimpleNamespace(
+            adapter_type=SimpleNamespace(value="equipment_asset_tools")
+        )
+
+
+def test_service_is_shared_not_per_consumer():
+    """Every consumer must resolve to the SAME service object.
+
+    Currently fails: there is no shared accessor, and each call site does
+    `ToolDiscoveryService()`, producing independent registries.
+    """
+    from src.api.services.mcp.tool_discovery import get_tool_discovery_service
+
+    assert get_tool_discovery_service() is get_tool_discovery_service()
+
+
+def test_source_registered_by_one_consumer_is_visible_to_another():
+    """An adapter registered by the equipment agent must be visible to the planner graph.
+
+    This is the exact production failure: the planner graph asks its own instance
+    and gets 0 tools while the agent's instance holds 4.
+    """
+    from src.api.services.mcp.tool_discovery import get_tool_discovery_service
+
+    async def scenario():
+        agent_view = get_tool_discovery_service()
+        await agent_view.register_discovery_source(
+            "equipment_asset_tools", _FakeAdapter(["get_equipment_status"]), "mcp_adapter"
+        )
+        await agent_view.discover_all_tools()
+
+        planner_view = get_tool_discovery_service()
+        # get_available_tools() returns List[Dict], not tool objects.
+        tools = await planner_view.get_available_tools()
+        names = {t["name"] for t in tools}
+        assert "get_equipment_status" in names, (
+            f"planner saw {len(tools)} tools {names}; registry is fragmented"
+        )
+
+    asyncio.run(scenario())
+
+
+def test_discovery_does_not_duplicate_tools_on_each_cycle():
+    """A tool must be registered once, not once per discovery cycle.
+
+    `register_discovery_source` runs an immediate discovery, and the 30s
+    `_discovery_loop` runs `discover_all_tools()` again -- each pass storing the
+    SAME tool under a fresh uuid4 key. The registry therefore grows without
+    bound while `_cleanup_old_data` reaps the stale copies 300s later, which is
+    the observed production churn:
+
+        Cleaned up 4 old tools
+        Tool discovery completed: 0 tools discovered from 0 sources
+
+    Expected: one logical tool -> one registry entry, however many cycles run.
+    """
+    from src.api.services.mcp.tool_discovery import get_tool_discovery_service
+
+    async def scenario():
+        svc = get_tool_discovery_service()
+        await svc.register_discovery_source(
+            "equipment_asset_tools", _FakeAdapter(["get_equipment_status"]), "mcp_adapter"
+        )
+        await svc.discover_all_tools()
+        await svc.discover_all_tools()
+
+        tools = await svc.get_available_tools()
+        matching = [t for t in tools if t["name"] == "get_equipment_status"]
+        assert len(matching) == 1, (
+            f"tool registered {len(matching)}x after 3 discovery passes; "
+            "registry duplicates on every cycle"
+        )
+
+    asyncio.run(scenario())
+
+
+def test_independent_instances_do_not_share_state():
+    """Documents the CURRENT broken behaviour so the fix is provably a change.
+
+    Two directly-constructed services must not see each other's sources. This
+    test passes today and must KEEP passing after the fix — direct construction
+    stays available for tests and isolation; only the shared accessor is added.
+    """
+
+    async def scenario():
+        a = ToolDiscoveryService()
+        b = ToolDiscoveryService()
+        await a.register_discovery_source(
+            "equipment_asset_tools", _FakeAdapter(["get_equipment_status"]), "mcp_adapter"
+        )
+        await a.discover_all_tools()
+
+        assert len(await b.get_available_tools()) == 0
+
+    asyncio.run(scenario())

--- a/tests/unit/test_mcp_integrated_planner_graph.py
+++ b/tests/unit/test_mcp_integrated_planner_graph.py
@@ -522,8 +522,10 @@ class TestMCPPlannerGraph:
     @pytest.mark.asyncio
     async def test_planner_graph_initialization_failure(self, planner_graph):
         """Test planner graph initialization with complete failure."""
+        # The graph now resolves the shared registry via get_tool_discovery_service()
+        # instead of constructing its own ToolDiscoveryService, so patch that symbol.
         with patch(
-            "src.api.graphs.mcp_integrated_planner_graph.ToolDiscoveryService",
+            "src.api.graphs.mcp_integrated_planner_graph.get_tool_discovery_service",
             side_effect=Exception("Init failed"),
         ):
             await planner_graph.initialize()


### PR DESCRIPTION
## Summary

Deploying this blueprint end-to-end (cloud NIM endpoints, CPU-only host, Docker Compose) produced correct dashboards but roughly **half of all chat queries returned `"The system is taking longer than expected to process it"`** instead of an answer. Root-causing that surfaced one primary defect plus four independent silent failures.

## 1. Fragmented tool-discovery registry — the cause of the timeouts

Nine call sites each did `ToolDiscoveryService()`, producing nine independent `discovered_tools` registries, nine 30s discovery loops and nine 300s cleanup loops. `mcp_integrated_planner_graph` built its own instance and registered no adapters into it, so it reported `Retrieved 0 available tools` while the equipment agent's instance held 4. Agents needing the tool list stalled to their 45s budget.

The signature is two different objects answering within the same second:

```
Tool discovery completed: 0 tools discovered from 0 sources
Tool discovery completed: 4 tools discovered from 1 sources
```

Adds `get_tool_discovery_service()` and migrates all nine sites.

The accessor is keyed **per event loop** (`WeakKeyDictionary` + lock) rather than a plain module global. This service owns background asyncio tasks that bind to whichever loop is running at `start_discovery()`; a global created under one loop and reused under another (`uvicorn --reload`, test suites) would hand out tasks attached to a dead loop — silent, and worse than the bug being fixed. Direct construction remains available for tests and deliberate isolation.

## 2. Registry duplicated on every discovery cycle

`DiscoveredTool.tool_id` defaults to a fresh `uuid4()` and `_discover_from_mcp_adapter` rebuilds tool objects each cycle, so the update-in-place branch in `_register_discovered_tool` could never match — a duplicate entry was stored every 30s, which `_cleanup_old_data` reaped 300s later (`Cleaned up N old tools`).

Fixed by making `tool_id` deterministic from `(source, name)`. The dict stays keyed by `tool_id`, because `tool_binding`, `tool_routing` and `tool_validation` all resolve tools via `discovered_tools.get(<tool_id>)`.

## 3. `NameError` in the chat error path

`_create_error_chat_response()` is called in two places but was never defined, so the error handler itself raised `NameError` and returned HTTP 500 instead of the intended graceful message.

## 4. `NameError` on every alert check

`check_alerts()` referenced `recent_requests`, which is local to `get_performance_stats()`. Every cycle logged `Error checking alerts: name 'recent_requests' is not defined`, and the timeout-rate alert never fired. Now uses `stats["total_requests"]`, already in scope.

## 5. TimescaleDB extension never installed

`000_schema.sql` and `001_equipment_schema.sql` both contain:

```sql
IF NOT EXISTS (SELECT 1 FROM pg_extension WHERE extname=timescaledb) THEN
```

`timescaledb` is unquoted, so the `IF` test raises before reaching `CREATE EXTENSION` — inside a `DO` block guarded by `EXCEPTION WHEN OTHERS THEN NULL`, which swallows it. A fresh database silently ends up with **no timescaledb extension and no hypertables** while every migration reports success. `000_schema.sql` also passes `create_hypertable()` unquoted identifiers.

Verified on a clean database:

| | extension | hypertables |
|---|---|---|
| before | `ABSENT` | none |
| after | `2.15.2` | `equipment_telemetry` |

…with 0 errors reported in both cases, which is precisely why this went unnoticed.

## 6. `start_server.sh` SIGKILLed an unrelated process

`lsof -ti:$PORT | xargs kill -9` destroys whatever owns the port — not necessarily a previous run of this server. On the test machine port 8001 was held by an unrelated local service, which was killed without warning. Now reports the owning PID and exits non-zero with instructions.

## Testing

- New `tests/test_tool_discovery_shared_registry.py` (4 tests): shared accessor identity, cross-consumer visibility, non-duplication across cycles, and that direct construction stays isolated.
- **Full suite: 32 failures on upstream `main`, 31 on this branch, zero newly failing.** Measured by stashing these changes and re-running the same selection, not by inspection.
- One existing test updated: `test_planner_graph_initialization_failure` patched `ToolDiscoveryService` to raise; it now patches `get_tool_discovery_service`, preserving intent.
- End-to-end: `"List equipment in Zone A"` returns real rows at confidence 0.95 after three MCP tool executions (previously a timeout fallback).

## Known remaining issue (not addressed here)

Conversationally phrased queries — `"Which forklifts have the lowest charge? Top three please."` — still fail. The failure mode changed from a 70s hang to routing at `general` with `No relevant tools found`. That is a separate routing-classification problem and is intentionally out of scope.

## Notes for reviewers

- Environment-specific workarounds used during testing (compose port remaps, dev-server proxy target) are deliberately **not** included.
- Tested against cloud NIM endpoints (`integrate.api.nvidia.com`) and additionally against a self-hosted `llama-3.3-nemotron-super-49b-v1.5` NIM on an RTX PRO 6000 Blackwell. The timeouts reproduced identically on both, confirming they are not inference-latency related.