### PR TITLE
feat(phase-9b): maiw_api canonical entrypoint and MAIWRuntime composition root

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -64,6 +64,8 @@ jobs:
         pip install -e packages/maiw-skills
         pip install -e packages/maiw-execution
         pip install -e packages/maiw-agents
+        pip install -e apps/api
+        pip install httpx
     
     - name: Install Node.js dependencies
       run: |
@@ -82,9 +84,9 @@ jobs:
       env:
         DATABASE_URL: postgresql://warehouse:ci_placeholder@localhost:5435/warehouse
       run: |
-        # CORE CI: unit + contract + mcp — no infrastructure required. Integration/e2e live in main.yml.
+        # CORE CI: unit + contract + mcp + api — no infrastructure required. Integration/e2e live in main.yml.
         # Canonical command matches docs/architecture/TEST_STRATEGY.md CORE CI definition.
-        pytest tests/unit tests/contract tests/mcp \
+        pytest tests/unit tests/contract tests/mcp tests/api \
           --timeout=120 \
           --ignore=tests/unit/test_mcp_integrated_planner_graph.py \
           --ignore=tests/unit/test_mcp_system.py \

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -282,14 +282,22 @@ jobs:
           source env/bin/activate
           set -a && source deploy/compose/.env && set +a
 
-          echo "Running start_server.sh in background..."
-          chmod +x ./scripts/start_server.sh
-          ./scripts/start_server.sh &
+          PORT=${PORT:-8001}
 
-          # Wait for server to start
-          echo "Waiting for API server to start..."
-          sleep 20
-          echo "✅ API server started"
+          # dev_up.sh (Step 5) may have already started wosa-backend on this port
+          # via Docker Compose.  If something is already listening, the running
+          # service is used for health checks; no second process is started.
+          if lsof -Pi :"$PORT" -sTCP:LISTEN -t >/dev/null 2>&1; then
+            echo "Port $PORT is already in use (wosa-backend Docker container)."
+            echo "Skipping local API server startup — using the running service."
+          else
+            echo "Running start_server.sh in background..."
+            chmod +x ./scripts/start_server.sh
+            ./scripts/start_server.sh &
+            echo "Waiting for API server to start..."
+            sleep 20
+          fi
+          echo "✅ API server ready"
 
       # Step 13: Start frontend
       - name: "Step 13: Start frontend"
@@ -438,6 +446,7 @@ jobs:
         with:
           name: production-deployment-checklist
           path: production-checklist.md
+          if-no-files-found: ignore
           retention-days: 90
   
       - name: Set result output

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -274,6 +274,10 @@ jobs:
           chmod +x ./scripts/setup/install_rapids.sh
           ./scripts/setup/install_rapids.sh || echo "⚠️ RAPIDS installation failed (will use CPU fallback)"
 
+          # RAPIDS may upgrade pandas to ≥3.0, which breaks nemoguardrails 0.23
+          # (requires pandas<3).  Re-pin after installation.
+          pip install --quiet 'pandas<3' || true
+
           echo "✅ RAPIDS GPU acceleration setup completed"
 
       # Step 12: Start API server
@@ -284,14 +288,15 @@ jobs:
 
           PORT=${PORT:-8001}
 
-          # dev_up.sh (Step 5) may have already started wosa-backend on this port
-          # via Docker Compose.  If something is already listening, the running
-          # service is used for health checks; no second process is started.
-          if lsof -Pi :"$PORT" -sTCP:LISTEN -t >/dev/null 2>&1; then
-            echo "Port $PORT is already in use (wosa-backend Docker container)."
-            echo "Skipping local API server startup — using the running service."
+          # dev_up.sh (Step 5) builds and starts wosa-backend via Docker Compose
+          # on port 8001.  Check for the named container first; fall back to a
+          # port-level check if the container name is unexpected.
+          if docker ps --format '{{.Names}}' | grep -q '^wosa-backend$'; then
+            echo "wosa-backend Docker container is running — using it for health checks."
+          elif lsof -Pi :"$PORT" -sTCP:LISTEN -t >/dev/null 2>&1; then
+            echo "Port $PORT is already occupied by another process — using it."
           else
-            echo "Running start_server.sh in background..."
+            echo "No existing API server found; starting local server..."
             chmod +x ./scripts/start_server.sh
             ./scripts/start_server.sh &
             echo "Waiting for API server to start..."
@@ -327,12 +332,13 @@ jobs:
       # Post-Deployment: Verify health checks and access points
       - name: "Verify: API health checks"
         run: |
-          # Wait for API to be fully ready
+          # Poll /api/v1/live (liveness probe — no DB/Redis/Milvus deps, always fast).
+          # The legacy /health path does not exist in maiw_api.app:app.
           max_retries=30
           retry_count=0
 
-          echo "Waiting for API server to be ready..."
-          until curl -f http://localhost:8001/health &>/dev/null || [ $retry_count -eq $max_retries ]; do
+          echo "Waiting for API server to be ready (polling /api/v1/live)..."
+          until curl -fsS http://localhost:8001/api/v1/live >/dev/null 2>&1 || [ $retry_count -eq $max_retries ]; do
             echo "Attempt $((retry_count + 1))/$max_retries: API not ready yet..."
             sleep 2
             retry_count=$((retry_count + 1))
@@ -340,20 +346,24 @@ jobs:
 
           if [ $retry_count -eq $max_retries ]; then
             echo "❌ API failed to start after $max_retries attempts"
+            echo "Docker status:"
+            docker ps --all --filter "name=wosa-backend"
+            echo "Docker logs (wosa-backend, last 50 lines):"
+            docker logs --tail 50 wosa-backend 2>&1 || true
             exit 1
           fi
 
           echo "✅ API is ready!"
 
-          # Test all health check endpoints (per DEPLOYMENT.md)
-          echo "Testing /health endpoint..."
-          curl -f http://localhost:8001/health || (echo "❌ /health failed" && exit 1)
+          # Test canonical health endpoints
+          echo "Testing /api/v1/live..."
+          curl -fsS http://localhost:8001/api/v1/live | python3 -m json.tool
 
-          echo "Testing /api/v1/health endpoint..."
-          curl -f http://localhost:8001/api/v1/health || (echo "❌ /api/v1/health failed" && exit 1)
+          echo "Testing /api/v1/health..."
+          curl -fsS http://localhost:8001/api/v1/health | python3 -m json.tool
 
-          echo "Testing /api/v1/health/simple endpoint..."
-          curl -f http://localhost:8001/api/v1/health/simple || (echo "❌ /api/v1/health/simple failed" && exit 1)
+          echo "Testing /api/v1/health/simple..."
+          curl -fsS http://localhost:8001/api/v1/health/simple | python3 -m json.tool
 
           echo "✅ All health checks passed!"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -116,4 +116,4 @@ HEALTHCHECK --interval=30s --timeout=30s --start-period=5s --retries=3 \
 EXPOSE 8001
 
 # Start command
-CMD ["uvicorn", "src.api.app:app", "--host", "0.0.0.0", "--port", "8001"]
+CMD ["uvicorn", "maiw_api.app:app", "--host", "0.0.0.0", "--port", "8001"]

--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -54,8 +54,12 @@ COPY --from=backend-deps /usr/local/bin /usr/local/bin
 # Security: Explicitly copy only required source code to prevent sensitive data exposure
 # .dockerignore provides additional protection as a defense-in-depth measure
 COPY src/ ./src/
+COPY apps/ ./apps/
 # Copy guardrails configuration (required for NeMo Guardrails)
 COPY data/config/guardrails/ ./data/config/guardrails/
+
+# Install the canonical API package
+RUN pip install --no-cache-dir -e apps/api
 
 # Build arguments for version injection
 ARG VERSION=0.0.0
@@ -84,5 +88,5 @@ HEALTHCHECK --interval=30s --timeout=30s --start-period=5s --retries=3 \
 EXPOSE 8001
 
 # Start command
-CMD ["uvicorn", "src.api.app:app", "--host", "0.0.0.0", "--port", "8001"]
+CMD ["uvicorn", "maiw_api.app:app", "--host", "0.0.0.0", "--port", "8001"]
 

--- a/README.md
+++ b/README.md
@@ -588,7 +588,7 @@ package-based, MCP v2 system.
 | **Agents** (`maiw-agents`) | ✅ Done | Equipment, Operations, Safety agents in canonical packages |
 | **MCP v2 servers** | ✅ Done | Inventory, Equipment, Labor, Wave — stateless HTTP |
 | **Capability contracts** | ✅ Done | All 12 capabilities defined, contract-tested |
-| **Compatibility shims** | ⚠️ Remove in 9B | `src/api/services/model_gateway/__init__.py`, `src/api/skills/*.py` |
+| **Compatibility shims** | ⚠️ Remove in Phase 10 | `src/api/services/model_gateway/__init__.py`, `src/api/skills/*.py` |
 | **Forecasting integration** | 🔄 Partial | `integrations/forecasting/` — multi-model ensemble, not wired to agents |
 | **Document processing** | 🔄 Partial | `integrations/document/` — OCR + extraction, not wired to agents |
 | **Simulation** | 🔲 Future | `integrations/simulation/` — placeholder only |

--- a/README.md
+++ b/README.md
@@ -282,14 +282,19 @@ Multi-Agent-Intelligent-Warehouse/
 │   ├── labor/                     # Labor capability server
 │   └── wave/                      # Wave capability server
 │
-├── src/api/                       # FastAPI application (current production entrypoint)
-│   ├── app.py                     # ASGI entrypoint: uvicorn src.api.app:app
-│   ├── routers/                   # HTTP route handlers
-│   ├── agents/                    # Legacy agent layer (being migrated to packages/)
-│   └── services/                  # Services: model_gateway shim, skills shim, auth, DB
+├── src/api/                       # Legacy FastAPI layer (routers being migrated to apps/api)
+│   ├── app.py                     # Legacy entrypoint (superseded by maiw_api.app)
+│   ├── routers/                   # HTTP route handlers (canonical ones moved to apps/api)
+│   ├── agents/                    # Legacy agent layer (superseded by packages/maiw-agents)
+│   └── services/                  # Services: auth, DB, monitoring, legacy shims
 │
-├── apps/api/maiw_api/             # Future application entrypoint (composition root)
-│   └── bootstrap.py               # MAIWRuntime dataclass, get_runtime() factory
+├── apps/api/maiw_api/             # Canonical FastAPI entrypoint (Phase 9B)
+│   ├── app.py                     # ASGI entrypoint: uvicorn maiw_api.app:app
+│   ├── bootstrap.py               # MAIWRuntime composition root
+│   ├── config.py                  # Application settings
+│   ├── dependencies.py            # FastAPI dependency helpers
+│   ├── lifespan.py                # Startup / shutdown
+│   └── routers/                   # Canonical routers (health, equipment, operations, safety, mcp)
 │
 ├── connectors/                    # Data source adapters
 │   └── generic/                   # Generic WMS connector (implemented)
@@ -480,7 +485,7 @@ cp .env.example .env
 ### API Server
 
 ```bash
-uvicorn src.api.app:app --reload --port 8001
+uvicorn maiw_api.app:app --reload --port 8001
 ```
 
 The API is available at `http://localhost:8001`. Key endpoints:
@@ -591,7 +596,7 @@ package-based, MCP v2 system.
 | **Training / flywheel** | 🔲 Future | `integrations/training/` — placeholder only |
 | **SAP EWM connector** | 🔲 Future | `connectors/` — generic connector implemented; SAP planned |
 | **Manhattan / Blue Yonder** | 🔲 Future | Planned WMS connectors |
-| **apps/api as entrypoint** | 🔲 Future | `apps/api/maiw_api/bootstrap.py` composition root exists; `src/api/app.py` is current production entrypoint |
+| **apps/api as entrypoint** | ✅ Phase 9B | `maiw_api.app:app` is the canonical entrypoint; `MAIWRuntime` is the composition root |
 
 ---
 

--- a/apps/api/maiw_api/app.py
+++ b/apps/api/maiw_api/app.py
@@ -1,0 +1,266 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""
+Canonical MAIW FastAPI entrypoint — Phase 9B.
+
+Entrypoint:
+    uvicorn maiw_api.app:app --host 0.0.0.0 --port 8001
+
+Router ownership:
+    Canonical (this package)
+        health       → maiw_api.routers.health
+        equipment    → maiw_api.routers.equipment     (canonical pipeline)
+        operations   → maiw_api.routers.operations    (SQL CRUD, bug-fixed)
+        safety       → maiw_api.routers.safety        (SQL CRUD)
+        mcp_status   → maiw_api.routers.mcp_status    (canonical MCP v2)
+
+    Keep temporarily (from src.api.routers)
+        auth, inventory, wms, iot, erp, scanning, attendance,
+        reasoning, migration, document, advanced_forecasting, training, chat
+
+    Removed (legacy custom MCP)
+        src.api.routers.mcp                           (replaced by mcp_status)
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+from dotenv import load_dotenv
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.exceptions import RequestValidationError
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse, Response
+
+from maiw_api.config import settings
+from maiw_api.lifespan import lifespan
+
+# ── Canonical routers ─────────────────────────────────────────────────────────
+from maiw_api.routers.health import router as health_router
+from maiw_api.routers.equipment import router as equipment_router
+from maiw_api.routers.operations import router as operations_router
+from maiw_api.routers.safety import router as safety_router
+from maiw_api.routers.mcp_status import router as mcp_status_router
+
+# ── Legacy routers (keep temporarily) ────────────────────────────────────────
+from src.api.routers.auth import router as auth_router
+from src.api.routers.inventory import router as inventory_router
+from src.api.routers.wms import router as wms_router
+from src.api.routers.iot import router as iot_router
+from src.api.routers.erp import router as erp_router
+from src.api.routers.scanning import router as scanning_router
+from src.api.routers.attendance import router as attendance_router
+from src.api.routers.reasoning import router as reasoning_router
+from src.api.routers.migration import router as migration_router
+from src.api.routers.document import router as document_router
+from src.api.routers.advanced_forecasting import router as forecasting_router
+from src.api.routers.training import router as training_router
+from src.api.routers.chat import router as chat_router
+
+# ── Shared middleware / monitoring (from src, no migration needed) ─────────────
+from src.api.middleware.security_headers import SecurityHeadersMiddleware
+from src.api.services.monitoring.metrics import record_request_metrics
+from src.api.services.security.rate_limiter import get_rate_limiter
+from src.api.utils.error_handler import (
+    handle_generic_exception,
+    handle_http_exception,
+    handle_validation_error,
+)
+
+load_dotenv()
+
+logger = logging.getLogger(__name__)
+
+
+def _safe_int_env(key: str, default: int) -> int:
+    value = os.getenv(key, str(default)).split("#")[0].strip()
+    try:
+        return int(value)
+    except ValueError:
+        return default
+
+
+_MAX_REQUEST_SIZE = _safe_int_env("MAX_REQUEST_SIZE", 10_485_760)  # 10 MB
+_MAX_UPLOAD_SIZE = _safe_int_env("MAX_UPLOAD_SIZE", 52_428_800)  # 50 MB
+
+# ── Application ───────────────────────────────────────────────────────────────
+
+app = FastAPI(
+    title=settings.app_title,
+    version=settings.app_version,
+    description=settings.app_description,
+    lifespan=lifespan,
+    max_request_size=_MAX_REQUEST_SIZE,
+)
+
+# ── Exception handlers ────────────────────────────────────────────────────────
+
+
+@app.exception_handler(RequestValidationError)
+async def validation_exception_handler(request: Request, exc: RequestValidationError):
+    return await handle_validation_error(request, exc)
+
+
+@app.exception_handler(HTTPException)
+async def http_exception_handler(request: Request, exc: HTTPException):
+    return await handle_http_exception(request, exc)
+
+
+@app.exception_handler(Exception)
+async def generic_exception_handler(request: Request, exc: Exception):
+    error_msg = str(exc)
+    # Preserve legacy chat-endpoint circular-reference guard
+    if "circular" in error_msg.lower() and request.url.path == "/api/v1/chat":
+        logger.error("Circular reference error in chat: %s", error_msg)
+        try:
+            return JSONResponse(
+                status_code=200,
+                content={
+                    "reply": (
+                        "I received your request, but there was an issue formatting "
+                        "the response. Please try again with a simpler question."
+                    ),
+                    "route": "error",
+                    "intent": "error",
+                    "session_id": "default",
+                    "confidence": 0.0,
+                    "error": "Response serialization failed",
+                    "error_type": "circular_reference",
+                },
+            )
+        except Exception:
+            return Response(
+                status_code=200,
+                content='{"reply":"Error processing request","route":"error","intent":"error","session_id":"default","confidence":0.0}',
+                media_type="application/json",
+            )
+    return await handle_generic_exception(request, exc)
+
+
+# ── Middleware (order matters — first added = outermost) ──────────────────────
+
+app.add_middleware(SecurityHeadersMiddleware)
+
+_cors_origins = [
+    o.strip()
+    for o in os.getenv(
+        "CORS_ORIGINS",
+        "http://localhost:3001,http://localhost:3000,"
+        "http://127.0.0.1:3001,http://127.0.0.1:3000",
+    ).split(",")
+    if o.strip()
+]
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=_cors_origins,
+    allow_credentials=True,
+    allow_methods=["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"],
+    allow_headers=["*"],
+    expose_headers=["*"],
+    max_age=3600,
+)
+
+_RATE_LIMIT_SKIP = frozenset(
+    {
+        "/health",
+        "/api/v1/health",
+        "/api/v1/health/simple",
+        "/api/v1/metrics",
+        "/docs",
+        "/openapi.json",
+        "/",
+    }
+)
+
+
+@app.middleware("http")
+async def rate_limit_middleware(request: Request, call_next):
+    if request.url.path not in _RATE_LIMIT_SKIP:
+        try:
+            limiter = await get_rate_limiter()
+            await limiter.check_rate_limit(request)
+        except HTTPException:
+            raise
+        except Exception as exc:
+            logger.error("Rate limiting error: %s", exc)
+    return await call_next(request)
+
+
+@app.middleware("http")
+async def request_size_middleware(request: Request, call_next):
+    content_length = request.headers.get("content-length")
+    if content_length:
+        try:
+            size = int(content_length)
+            max_size = (
+                _MAX_UPLOAD_SIZE
+                if (
+                    "/document/upload" in request.url.path
+                    or "/upload" in request.url.path
+                )
+                else _MAX_REQUEST_SIZE
+            )
+            if size > max_size:
+                raise HTTPException(
+                    status_code=413,
+                    detail=f"Request too large: {size} bytes (max {max_size})",
+                )
+        except ValueError:
+            pass
+    return await call_next(request)
+
+
+@app.middleware("http")
+async def metrics_middleware(request: Request, call_next):
+    import time
+
+    start = time.time()
+    response = await call_next(request)
+    duration = time.time() - start
+    try:
+        record_request_metrics(
+            method=request.method,
+            path=request.url.path,
+            status_code=response.status_code,
+            duration=duration,
+        )
+    except Exception:
+        pass
+    return response
+
+
+# ── Routers ───────────────────────────────────────────────────────────────────
+
+# Canonical (Phase 9B)
+app.include_router(health_router)
+app.include_router(equipment_router)
+app.include_router(operations_router)
+app.include_router(safety_router)
+app.include_router(mcp_status_router)
+
+# Legacy (keep temporarily)
+app.include_router(auth_router)
+app.include_router(inventory_router)
+app.include_router(wms_router)
+app.include_router(iot_router)
+app.include_router(erp_router)
+app.include_router(scanning_router)
+app.include_router(attendance_router)
+app.include_router(reasoning_router)
+app.include_router(migration_router)
+app.include_router(document_router)
+app.include_router(forecasting_router)
+app.include_router(training_router)
+app.include_router(chat_router)
+
+
+@app.get("/")
+async def root():
+    return {
+        "service": settings.app_title,
+        "version": settings.app_version,
+        "pipeline": "STATE → REASON → PROPOSE → DECIDE → EXECUTE → MCP → BACKEND",
+        "docs": "/docs",
+        "health": "/api/v1/health",
+    }

--- a/apps/api/maiw_api/bootstrap.py
+++ b/apps/api/maiw_api/bootstrap.py
@@ -1,29 +1,35 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 """
-MAIW API Composition Root.
+MAIW API Composition Root — Phase 9B.
 
-This module is the single place where the runtime object graph is assembled:
+MAIWRuntime is the single place where the runtime object graph is assembled:
 
+    CapabilityRegistry  (all MCP domains registered)
+    MAIWMCPClient       (shared across all skills)
+    Read skills         (status, capacity, wave-get)
+    WarehouseStateProvider
+    Execution skills    (assign, release, maintenance, allocate, reprioritize)
+    ActionExecutors     (Equipment, Labor, Wave)
     ModelGateway
-    MCP clients (per domain)
-    StateProvider
     DecisionEngine
-    ActionExecutors (Equipment, Labor, Wave)
-    Agent instances
+    EquipmentAssetOperationsAgent
+    OperationsCoordinationAgent
+    SafetyComplianceAgent
 
-Phase 8 status: Structure is defined; full wiring is deferred to Phase 9
-when agents are migrated from src/api/agents/ to packages/maiw-agents/.
+Dependency direction:
+    apps/api → packages/* (one-way)
+    packages/* never import from apps/api
 
 Usage:
-    from apps.api.maiw_api.bootstrap import get_runtime
+    from maiw_api.bootstrap import get_runtime
     runtime = await get_runtime()
-    gateway = runtime.model_gateway
 """
 
 from __future__ import annotations
 
 import logging
+import os
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -31,36 +37,76 @@ logger = logging.getLogger(__name__)
 
 _runtime: "MAIWRuntime | None" = None
 
+_EQUIPMENT_CAPABILITIES = [
+    "warehouse.equipment.get_status",
+    "warehouse.equipment.get_telemetry",
+    "warehouse.equipment.assign",
+    "warehouse.equipment.release",
+    "warehouse.equipment.schedule_maintenance",
+]
+
+_LABOR_CAPABILITIES = [
+    "warehouse.labor.get_capacity",
+    "warehouse.labor.get_allocation",
+    "warehouse.labor.allocate",
+]
+
+_WAVE_CAPABILITIES = [
+    "warehouse.wave.get",
+    "warehouse.wave.get_risk",
+    "warehouse.wave.reprioritize",
+]
+
+_INVENTORY_CAPABILITIES = [
+    "warehouse.inventory.get",
+    "warehouse.inventory.locate",
+]
+
 
 @dataclass
 class MAIWRuntime:
     """
-    Container for all lazily-initialized runtime singletons.
+    Process-level singleton that holds all runtime objects.
 
-    Agents and routers receive runtime objects through this container rather
-    than constructing their own dependencies.
+    Agents and routers receive dependencies through this container rather than
+    constructing their own.  All fields default to None; routers guard against
+    None values and return 503 when a required component is unavailable.
     """
 
+    # MCP layer
+    mcp_registry: Any = None  # maiw_mcp.CapabilityRegistry
+    mcp_client: Any = None  # maiw_mcp.MAIWMCPClient
+
+    # Availability flags (True = successfully initialised at startup)
+    mcp_inventory_available: bool = False
+    mcp_equipment_available: bool = False
+    mcp_labor_available: bool = False
+    mcp_wave_available: bool = False
+
+    # Model + decision
     model_gateway: Any = None  # maiw_models.ModelGateway
     decision_engine: Any = None  # maiw_decision.DecisionEngine
+
+    # State
+    state_provider: Any = None  # maiw_state.WarehouseStateProvider
+
+    # Executors
     equipment_executor: Any = None  # maiw_execution.EquipmentActionExecutor
     labor_executor: Any = None  # maiw_execution.LaborActionExecutor
     wave_executor: Any = None  # maiw_execution.WaveActionExecutor
-    state_provider: Any = None  # WarehouseStateProvider
+
+    # Canonical agents
     equipment_agent: Any = None  # maiw_agents.equipment.EquipmentAssetOperationsAgent
     operations_agent: Any = None  # maiw_agents.operations.OperationsCoordinationAgent
     safety_agent: Any = None  # maiw_agents.safety.SafetyComplianceAgent
-    equipment_executor: Any = None  # EquipmentActionExecutor
-    labor_executor: Any = None  # LaborActionExecutor
-    wave_executor: Any = None  # WaveActionExecutor
-    state_provider: Any = None  # WarehouseStateProvider
 
 
 async def get_runtime() -> MAIWRuntime:
     """
     Return (or build) the process-level runtime singleton.
 
-    Call once at application startup; subsequent calls return the same object.
+    Safe to call multiple times — returns the cached instance after the
+    first successful build.  Called once from the FastAPI lifespan.
     """
     global _runtime
     if _runtime is not None:
@@ -69,97 +115,187 @@ async def get_runtime() -> MAIWRuntime:
     logger.info("MAIW bootstrap: assembling runtime...")
     runtime = MAIWRuntime()
 
-    # ModelGateway
+    # ── 1. CapabilityRegistry ──────────────────────────────────────────────────
+    try:
+        from maiw_mcp.registry.registry import CapabilityRegistry
+
+        registry = CapabilityRegistry()
+
+        inventory_url = os.getenv("MAIW_MCP_SERVER_INVENTORY_URL")
+        if inventory_url:
+            registry.register_domain(_INVENTORY_CAPABILITIES, inventory_url)
+            runtime.mcp_inventory_available = True
+
+        equipment_url = os.getenv("MAIW_MCP_SERVER_EQUIPMENT_URL")
+        if equipment_url:
+            registry.register_domain(_EQUIPMENT_CAPABILITIES, equipment_url)
+            runtime.mcp_equipment_available = True
+
+        labor_url = os.getenv("MAIW_MCP_SERVER_LABOR_URL")
+        if labor_url:
+            registry.register_domain(_LABOR_CAPABILITIES, labor_url)
+            runtime.mcp_labor_available = True
+
+        wave_url = os.getenv("MAIW_MCP_SERVER_WAVE_URL")
+        if wave_url:
+            registry.register_domain(_WAVE_CAPABILITIES, wave_url)
+            runtime.mcp_wave_available = True
+
+        runtime.mcp_registry = registry
+        logger.info(
+            "MAIW bootstrap: CapabilityRegistry ready — %d capabilities registered",
+            len(registry.all_capabilities()),
+        )
+    except Exception as exc:
+        logger.warning("MAIW bootstrap: CapabilityRegistry unavailable — %s", exc)
+
+    # ── 2. MAIWMCPClient ──────────────────────────────────────────────────────
+    if runtime.mcp_registry is not None:
+        try:
+            from maiw_mcp.client.client import MAIWMCPClient
+
+            runtime.mcp_client = MAIWMCPClient(runtime.mcp_registry)
+            logger.info("MAIW bootstrap: MAIWMCPClient ready")
+        except Exception as exc:
+            logger.warning("MAIW bootstrap: MAIWMCPClient unavailable — %s", exc)
+
+    # ── 3. ModelGateway ───────────────────────────────────────────────────────
     try:
         from maiw_models import get_model_gateway
+
         runtime.model_gateway = await get_model_gateway()
         logger.info("MAIW bootstrap: ModelGateway ready")
     except Exception as exc:
         logger.warning("MAIW bootstrap: ModelGateway unavailable — %s", exc)
 
-    # DecisionEngine (synchronous, no I/O)
+    # ── 4. DecisionEngine ─────────────────────────────────────────────────────
     try:
         from maiw_decision import DecisionEngine
+
         runtime.decision_engine = DecisionEngine()
         logger.info("MAIW bootstrap: DecisionEngine ready")
     except Exception as exc:
         logger.warning("MAIW bootstrap: DecisionEngine unavailable — %s", exc)
 
-    # EquipmentActionExecutor (Phase 9A: migrated to maiw_execution)
-    try:
-        from maiw_execution import EquipmentActionExecutor
-    # EquipmentActionExecutor
-    try:
-        from src.api.agents.inventory.action_executor import EquipmentActionExecutor
-        from maiw_skills.equipment import (
-            get_execute_equipment_assignment_skill,
-            get_execute_equipment_release_skill,
-            get_execute_equipment_maintenance_skill,
-        )
-        runtime.equipment_executor = EquipmentActionExecutor(
-            assign_skill=await get_execute_equipment_assignment_skill(),
-            release_skill=await get_execute_equipment_release_skill(),
-            maintenance_skill=await get_execute_equipment_maintenance_skill(),
-            state_provider=runtime.state_provider,
-        )
-        logger.info("MAIW bootstrap: EquipmentActionExecutor ready")
-    except Exception as exc:
-        logger.warning("MAIW bootstrap: EquipmentActionExecutor unavailable — %s", exc)
+    # ── 5. Read skills + WarehouseStateProvider ───────────────────────────────
+    if runtime.mcp_client is not None:
+        try:
+            from maiw_skills.equipment.skills import EquipmentStatusSkill
+            from maiw_state import WarehouseStateProvider
 
-    # LaborActionExecutor (Phase 9A: migrated to maiw_execution)
-    try:
-        from maiw_execution import LaborActionExecutor
-    # LaborActionExecutor
-    try:
-        from src.api.agents.operations.labor_executor import LaborActionExecutor
-        from maiw_skills.labor import get_execute_labor_allocation_skill
-        runtime.labor_executor = LaborActionExecutor(
-            allocate_skill=await get_execute_labor_allocation_skill(),
-        )
-        logger.info("MAIW bootstrap: LaborActionExecutor ready")
-    except Exception as exc:
-        logger.warning("MAIW bootstrap: LaborActionExecutor unavailable — %s", exc)
+            equipment_status_skill = EquipmentStatusSkill(runtime.mcp_client)
+            runtime.state_provider = WarehouseStateProvider(
+                equipment_status_skill=equipment_status_skill,
+            )
+            logger.info("MAIW bootstrap: WarehouseStateProvider ready")
+        except Exception as exc:
+            logger.warning(
+                "MAIW bootstrap: WarehouseStateProvider unavailable — %s", exc
+            )
 
-    # WaveActionExecutor (Phase 9A: migrated to maiw_execution)
-    try:
-        from maiw_execution import WaveActionExecutor
-    # WaveActionExecutor
-    try:
-        from src.api.agents.operations.wave_executor import WaveActionExecutor
-        from maiw_skills.wave import get_execute_wave_reprioritization_skill
-        runtime.wave_executor = WaveActionExecutor(
-            reprioritize_skill=await get_execute_wave_reprioritization_skill(),
-        )
-        logger.info("MAIW bootstrap: WaveActionExecutor ready")
-    except Exception as exc:
-        logger.warning("MAIW bootstrap: WaveActionExecutor unavailable — %s", exc)
+    # ── 6. Equipment execution skills + EquipmentActionExecutor ──────────────
+    if runtime.mcp_client is not None and runtime.mcp_equipment_available:
+        try:
+            from maiw_skills.equipment.skills import (
+                ExecuteEquipmentAssignmentSkill,
+                ExecuteEquipmentMaintenanceSkill,
+                ExecuteEquipmentReleaseSkill,
+            )
+            from maiw_execution import EquipmentActionExecutor
 
-    # EquipmentAssetOperationsAgent (Phase 9A: new maiw_agents package)
+            assign_skill = ExecuteEquipmentAssignmentSkill(runtime.mcp_client)
+            release_skill = ExecuteEquipmentReleaseSkill(runtime.mcp_client)
+            maintenance_skill = ExecuteEquipmentMaintenanceSkill(runtime.mcp_client)
+
+            runtime.equipment_executor = EquipmentActionExecutor(
+                assign_skill=assign_skill,
+                release_skill=release_skill,
+                maintenance_skill=maintenance_skill,
+                state_provider=runtime.state_provider,
+            )
+            logger.info("MAIW bootstrap: EquipmentActionExecutor ready")
+        except Exception as exc:
+            logger.warning(
+                "MAIW bootstrap: EquipmentActionExecutor unavailable — %s", exc
+            )
+
+    # ── 7. Labor execution skill + LaborActionExecutor ────────────────────────
+    if runtime.mcp_client is not None and runtime.mcp_labor_available:
+        try:
+            from maiw_skills.labor.skills import ExecuteLaborAllocationSkill
+            from maiw_execution import LaborActionExecutor
+
+            allocate_skill = ExecuteLaborAllocationSkill(runtime.mcp_client)
+            runtime.labor_executor = LaborActionExecutor(allocate_skill=allocate_skill)
+            logger.info("MAIW bootstrap: LaborActionExecutor ready")
+        except Exception as exc:
+            logger.warning("MAIW bootstrap: LaborActionExecutor unavailable — %s", exc)
+
+    # ── 8. Wave execution skill + WaveActionExecutor ──────────────────────────
+    if runtime.mcp_client is not None and runtime.mcp_wave_available:
+        try:
+            from maiw_skills.wave.skills import ExecuteWaveReprioritizationSkill
+            from maiw_execution import WaveActionExecutor
+
+            reprioritize_skill = ExecuteWaveReprioritizationSkill(runtime.mcp_client)
+            runtime.wave_executor = WaveActionExecutor(
+                reprioritize_skill=reprioritize_skill
+            )
+            logger.info("MAIW bootstrap: WaveActionExecutor ready")
+        except Exception as exc:
+            logger.warning("MAIW bootstrap: WaveActionExecutor unavailable — %s", exc)
+
+    # ── 9. EquipmentAssetOperationsAgent ─────────────────────────────────────
     try:
         from maiw_agents.equipment import EquipmentAssetOperationsAgent
+        from maiw_skills.equipment.skills import EquipmentAssignmentSkill
+
+        assignment_skill = EquipmentAssignmentSkill()
+
+        # EquipmentAssetTools is an integration adapter (SQL + MCP reads).
+        # It is optional — the agent degrades gracefully without it.
+        asset_tools = None
+        try:
+            from src.api.agents.inventory.equipment_asset_tools import (
+                get_equipment_asset_tools,
+            )
+
+            asset_tools = await get_equipment_asset_tools()
+            logger.info("MAIW bootstrap: EquipmentAssetTools ready")
+        except Exception as exc:
+            logger.warning("MAIW bootstrap: EquipmentAssetTools unavailable — %s", exc)
+
         runtime.equipment_agent = EquipmentAssetOperationsAgent(
             model_gateway=runtime.model_gateway,
-            decision_engine=runtime.decision_engine,
-            action_executor=runtime.equipment_executor,
+            asset_tools=asset_tools,
             state_provider=runtime.state_provider,
+            decision_engine=runtime.decision_engine,
+            assignment_skill=assignment_skill,
+            action_executor=runtime.equipment_executor,
         )
         logger.info("MAIW bootstrap: EquipmentAssetOperationsAgent ready")
     except Exception as exc:
-        logger.warning("MAIW bootstrap: EquipmentAssetOperationsAgent unavailable — %s", exc)
+        logger.warning(
+            "MAIW bootstrap: EquipmentAssetOperationsAgent unavailable — %s", exc
+        )
 
-    # OperationsCoordinationAgent (Phase 9A: new maiw_agents package)
+    # ── 10. OperationsCoordinationAgent ───────────────────────────────────────
     try:
         from maiw_agents.operations import OperationsCoordinationAgent
+
         runtime.operations_agent = OperationsCoordinationAgent(
             model_gateway=runtime.model_gateway,
         )
         logger.info("MAIW bootstrap: OperationsCoordinationAgent ready")
     except Exception as exc:
-        logger.warning("MAIW bootstrap: OperationsCoordinationAgent unavailable — %s", exc)
+        logger.warning(
+            "MAIW bootstrap: OperationsCoordinationAgent unavailable — %s", exc
+        )
 
-    # SafetyComplianceAgent (Phase 9A: new maiw_agents package)
+    # ── 11. SafetyComplianceAgent ─────────────────────────────────────────────
     try:
         from maiw_agents.safety import SafetyComplianceAgent
+
         runtime.safety_agent = SafetyComplianceAgent(
             model_gateway=runtime.model_gateway,
         )

--- a/apps/api/maiw_api/config.py
+++ b/apps/api/maiw_api/config.py
@@ -1,0 +1,103 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""
+Application settings for the MAIW API.
+
+All configuration is read from environment variables.  Defaults are chosen
+to be safe for local development — production deployments must supply values
+for all settings without defaults.
+"""
+
+from __future__ import annotations
+
+import os
+
+
+def _bool(key: str, default: bool = False) -> bool:
+    return os.getenv(key, str(default)).lower() in ("1", "true", "yes")
+
+
+def _int(key: str, default: int) -> int:
+    try:
+        return int(os.getenv(key, str(default)))
+    except ValueError:
+        return default
+
+
+class Settings:
+    """Reads configuration from the process environment at access time."""
+
+    # ── API metadata ──────────────────────────────────────────────────────────
+    @property
+    def app_title(self) -> str:
+        return os.getenv("MAIW_APP_TITLE", "Multi-Agent Intelligent Warehouse API")
+
+    @property
+    def app_version(self) -> str:
+        return os.getenv("MAIW_APP_VERSION", "0.1.0")
+
+    @property
+    def app_description(self) -> str:
+        return "MAIW canonical API — STATE → REASON → PROPOSE → DECIDE → EXECUTE → MCP"
+
+    # ── Server ────────────────────────────────────────────────────────────────
+    @property
+    def host(self) -> str:
+        return os.getenv("MAIW_API_HOST", "0.0.0.0")
+
+    @property
+    def port(self) -> int:
+        return _int("MAIW_API_PORT", 8001)
+
+    @property
+    def reload(self) -> bool:
+        return _bool("MAIW_API_RELOAD", False)
+
+    # ── CORS ──────────────────────────────────────────────────────────────────
+    @property
+    def cors_origins(self) -> list[str]:
+        raw = os.getenv("MAIW_CORS_ORIGINS", "*")
+        return [o.strip() for o in raw.split(",") if o.strip()]
+
+    @property
+    def cors_allow_credentials(self) -> bool:
+        return _bool("MAIW_CORS_ALLOW_CREDENTIALS", False)
+
+    # ── Security ──────────────────────────────────────────────────────────────
+    @property
+    def secret_key(self) -> str:
+        return os.getenv("SECRET_KEY", "dev-insecure-key-change-in-production")
+
+    # ── MCP server URLs (read-only mirror — bootstrap uses these via os.getenv) ──
+    @property
+    def mcp_inventory_url(self) -> str | None:
+        return os.getenv("MAIW_MCP_SERVER_INVENTORY_URL")
+
+    @property
+    def mcp_equipment_url(self) -> str | None:
+        return os.getenv("MAIW_MCP_SERVER_EQUIPMENT_URL")
+
+    @property
+    def mcp_labor_url(self) -> str | None:
+        return os.getenv("MAIW_MCP_SERVER_LABOR_URL")
+
+    @property
+    def mcp_wave_url(self) -> str | None:
+        return os.getenv("MAIW_MCP_SERVER_WAVE_URL")
+
+    # ── Rate limiting ─────────────────────────────────────────────────────────
+    @property
+    def rate_limit_requests(self) -> int:
+        return _int("MAIW_RATE_LIMIT_REQUESTS", 100)
+
+    @property
+    def rate_limit_window_seconds(self) -> int:
+        return _int("MAIW_RATE_LIMIT_WINDOW_SECONDS", 60)
+
+    # ── Request limits ────────────────────────────────────────────────────────
+    @property
+    def max_request_size_bytes(self) -> int:
+        return _int("MAIW_MAX_REQUEST_SIZE_BYTES", 10 * 1024 * 1024)  # 10 MB
+
+
+settings = Settings()

--- a/apps/api/maiw_api/dependencies.py
+++ b/apps/api/maiw_api/dependencies.py
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""
+FastAPI dependency helpers for the MAIW API.
+
+All routers import ``get_runtime`` from here rather than from bootstrap
+directly, keeping the dependency injection surface small and mockable in tests.
+
+Usage in a router:
+
+    from maiw_api.dependencies import get_runtime
+    from maiw_api.bootstrap import MAIWRuntime
+
+    @router.get("/example")
+    async def example(runtime: MAIWRuntime = Depends(get_runtime)):
+        ...
+"""
+
+from __future__ import annotations
+
+from fastapi import Request
+
+from maiw_api.bootstrap import MAIWRuntime
+
+
+async def get_runtime(request: Request) -> MAIWRuntime:
+    """
+    Return the MAIWRuntime stored on ``app.state.runtime``.
+
+    The lifespan function sets ``app.state.runtime`` at startup.
+    Tests can override it by setting ``app.state.runtime`` directly
+    before calling the test client.
+    """
+    return request.app.state.runtime

--- a/apps/api/maiw_api/lifespan.py
+++ b/apps/api/maiw_api/lifespan.py
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""
+FastAPI lifespan — startup and shutdown logic for the MAIW API.
+
+The lifespan assembles the MAIWRuntime once and stores it on
+``app.state.runtime`` so that routers can retrieve it via the
+``get_runtime`` dependency.
+
+Usage in app.py:
+
+    from maiw_api.lifespan import lifespan
+    app = FastAPI(lifespan=lifespan)
+"""
+
+from __future__ import annotations
+
+import logging
+from contextlib import asynccontextmanager
+
+from fastapi import FastAPI
+
+from maiw_api.bootstrap import get_runtime
+
+logger = logging.getLogger(__name__)
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    """Build the runtime on startup; release resources on shutdown."""
+    logger.info("MAIW API: starting up...")
+
+    runtime = await get_runtime()
+    app.state.runtime = runtime
+
+    logger.info(
+        "MAIW API: startup complete — "
+        "equipment_agent=%s, operations_agent=%s, safety_agent=%s, "
+        "mcp_inventory=%s, mcp_equipment=%s, mcp_labor=%s, mcp_wave=%s",
+        runtime.equipment_agent is not None,
+        runtime.operations_agent is not None,
+        runtime.safety_agent is not None,
+        runtime.mcp_inventory_available,
+        runtime.mcp_equipment_available,
+        runtime.mcp_labor_available,
+        runtime.mcp_wave_available,
+    )
+
+    yield
+
+    logger.info("MAIW API: shutting down...")

--- a/apps/api/maiw_api/routers/equipment.py
+++ b/apps/api/maiw_api/routers/equipment.py
@@ -32,10 +32,18 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/v1", tags=["Equipment"])
 
-# Module-level SQL retriever — no async state, safe to share
-from src.retrieval.structured import SQLRetriever
+# Lazy-init: deferred import so importing this module does not require asyncpg.
+# asyncpg is only pulled in when the first request initialises the connection.
+_sql = None
 
-_sql = SQLRetriever()
+
+def _get_sql():
+    global _sql
+    if _sql is None:
+        from src.retrieval.structured import SQLRetriever
+
+        _sql = SQLRetriever()
+    return _sql
 
 
 # ── Request / Response models ─────────────────────────────────────────────────
@@ -171,7 +179,8 @@ async def get_all_equipment(
 ):
     """List equipment assets with optional filtering."""
     try:
-        await _sql.initialize()
+        sql = _get_sql()
+        await sql.initialize()
 
         conditions, params, n = [], [], 1
         if equipment_type:
@@ -195,7 +204,7 @@ async def get_all_equipment(
             WHERE {where}
             ORDER BY asset_id
         """
-        rows = await _sql.execute_query(query, tuple(params))
+        rows = await sql.execute_query(query, tuple(params))
         return [_row_to_asset(r) for r in rows]
     except Exception as exc:
         logger.error("Failed to list equipment assets: %s", exc)
@@ -217,7 +226,8 @@ async def get_equipment_assignments(
 ):
     """List equipment assignments with optional filters."""
     try:
-        await _sql.initialize()
+        sql = _get_sql()
+        await sql.initialize()
 
         parts = [
             "SELECT id, asset_id, task_id, assignee, assignment_type, "
@@ -238,7 +248,7 @@ async def get_equipment_assignments(
             parts.append("WHERE " + " AND ".join(conditions))
         parts.append("ORDER BY assigned_at DESC")
 
-        rows = await _sql.execute_query(" ".join(parts), tuple(params))
+        rows = await sql.execute_query(" ".join(parts), tuple(params))
         return [
             EquipmentAssignment(
                 id=r["id"],
@@ -304,8 +314,9 @@ async def get_maintenance_schedule(
 async def get_equipment_by_id(asset_id: str):
     """Get a single equipment asset by ID."""
     try:
-        await _sql.initialize()
-        rows = await _sql.execute_query(
+        sql = _get_sql()
+        await sql.initialize()
+        rows = await sql.execute_query(
             """
             SELECT asset_id, type, model, zone, status, owner_user,
                    next_pm_due, last_maintenance, created_at, updated_at, metadata

--- a/apps/api/maiw_api/routers/equipment.py
+++ b/apps/api/maiw_api/routers/equipment.py
@@ -1,0 +1,506 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""
+Equipment router — Batch C.
+
+Key change from src/api/routers/equipment.py:
+- Write paths (assign, release, maintenance) use ``runtime.equipment_agent``
+  from MAIWRuntime instead of the legacy ``get_equipment_agent()`` factory.
+- Read-list / filter paths still use SQLRetriever directly (no agent needed).
+- The live status path uses ``runtime.equipment_agent`` for the state snapshot.
+
+All write paths go through the canonical STATE → REASON → PROPOSE → DECIDE pipeline.
+Reads are always direct DB queries — no pipeline, no latency.
+
+If ``runtime.equipment_agent`` is None at startup (MCP server not configured),
+write endpoints return 503 rather than 500.
+"""
+
+from __future__ import annotations
+
+import ast
+import logging
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from pydantic import BaseModel
+
+from maiw_api.dependencies import get_runtime
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/v1", tags=["Equipment"])
+
+# Module-level SQL retriever — no async state, safe to share
+from src.retrieval.structured import SQLRetriever
+
+_sql = SQLRetriever()
+
+
+# ── Request / Response models ─────────────────────────────────────────────────
+
+
+class EquipmentAsset(BaseModel):
+    asset_id: str
+    type: str
+    model: Optional[str] = None
+    zone: Optional[str] = None
+    status: str
+    owner_user: Optional[str] = None
+    next_pm_due: Optional[str] = None
+    last_maintenance: Optional[str] = None
+    created_at: str
+    updated_at: str
+    metadata: Dict[str, Any] = {}
+
+
+class EquipmentAssignment(BaseModel):
+    id: int
+    asset_id: str
+    task_id: Optional[str] = None
+    assignee: str
+    assignment_type: str
+    assigned_at: str
+    released_at: Optional[str] = None
+    notes: Optional[str] = None
+
+
+class EquipmentTelemetry(BaseModel):
+    timestamp: str
+    asset_id: str
+    metric: str
+    value: float
+    unit: str
+    quality_score: float
+
+
+class MaintenanceRecord(BaseModel):
+    id: int
+    asset_id: str
+    maintenance_type: str
+    description: str
+    performed_by: str
+    performed_at: str
+    duration_minutes: int
+    cost: Optional[float] = None
+    notes: Optional[str] = None
+
+
+class AssignmentRequest(BaseModel):
+    asset_id: str
+    assignee: str
+    assignment_type: str = "task"
+    task_id: Optional[str] = None
+    duration_hours: Optional[int] = None
+    notes: Optional[str] = None
+    warehouse_id: Optional[str] = None
+
+
+class ReleaseRequest(BaseModel):
+    asset_id: str
+    released_by: str
+    notes: Optional[str] = None
+    warehouse_id: Optional[str] = None
+
+
+class MaintenanceRequest(BaseModel):
+    asset_id: str
+    maintenance_type: str
+    description: str
+    scheduled_by: str
+    scheduled_for: str
+    estimated_duration_minutes: int = 60
+    priority: str = "medium"
+    warehouse_id: Optional[str] = None
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+
+def _parse_metadata(raw: Any) -> dict:
+    if isinstance(raw, dict):
+        return raw
+    if raw and raw != "{}":
+        try:
+            return ast.literal_eval(raw)
+        except Exception:
+            return {}
+    return {}
+
+
+def _row_to_asset(row: dict) -> EquipmentAsset:
+    return EquipmentAsset(
+        asset_id=row["asset_id"],
+        type=row["type"],
+        model=row["model"],
+        zone=row["zone"],
+        status=row["status"],
+        owner_user=row["owner_user"],
+        next_pm_due=row["next_pm_due"].isoformat() if row["next_pm_due"] else None,
+        last_maintenance=(
+            row["last_maintenance"].isoformat() if row["last_maintenance"] else None
+        ),
+        created_at=row["created_at"].isoformat(),
+        updated_at=row["updated_at"].isoformat(),
+        metadata=_parse_metadata(row["metadata"]),
+    )
+
+
+def _require_agent(runtime, name: str = "equipment_agent"):
+    agent = getattr(runtime, name, None)
+    if agent is None:
+        raise HTTPException(
+            status_code=503,
+            detail=(
+                f"{name} is not available — MCP server may not be configured. "
+                "Check MAIW_MCP_SERVER_EQUIPMENT_URL."
+            ),
+        )
+    return agent
+
+
+# ── Read endpoints (SQL, no agent) ────────────────────────────────────────────
+
+
+@router.get("/equipment", response_model=List[EquipmentAsset])
+async def get_all_equipment(
+    equipment_type: Optional[str] = None,
+    zone: Optional[str] = None,
+    status: Optional[str] = None,
+):
+    """List equipment assets with optional filtering."""
+    try:
+        await _sql.initialize()
+
+        conditions, params, n = [], [], 1
+        if equipment_type:
+            conditions.append(f"type = ${n}")
+            params.append(equipment_type)
+            n += 1
+        if zone:
+            conditions.append(f"zone = ${n}")
+            params.append(zone)
+            n += 1
+        if status:
+            conditions.append(f"status = ${n}")
+            params.append(status)
+            n += 1
+
+        where = " AND ".join(conditions) if conditions else "1=1"
+        query = f"""
+            SELECT asset_id, type, model, zone, status, owner_user,
+                   next_pm_due, last_maintenance, created_at, updated_at, metadata
+            FROM equipment_assets
+            WHERE {where}
+            ORDER BY asset_id
+        """
+        rows = await _sql.execute_query(query, tuple(params))
+        return [_row_to_asset(r) for r in rows]
+    except Exception as exc:
+        logger.error("Failed to list equipment assets: %s", exc)
+        raise HTTPException(
+            status_code=500, detail="Failed to retrieve equipment assets"
+        )
+
+
+@router.get("/equipment/assignments/test")
+async def test_assignments():
+    return {"message": "Assignments endpoint is working"}
+
+
+@router.get("/equipment/assignments", response_model=List[EquipmentAssignment])
+async def get_equipment_assignments(
+    asset_id: Optional[str] = None,
+    assignee: Optional[str] = None,
+    active_only: bool = True,
+):
+    """List equipment assignments with optional filters."""
+    try:
+        await _sql.initialize()
+
+        parts = [
+            "SELECT id, asset_id, task_id, assignee, assignment_type, "
+            "assigned_at, released_at, notes FROM equipment_assignments"
+        ]
+        conditions, params, n = [], [], 0
+        if asset_id:
+            n += 1
+            conditions.append(f"asset_id = ${n}")
+            params.append(asset_id)
+        if assignee:
+            n += 1
+            conditions.append(f"assignee = ${n}")
+            params.append(assignee)
+        if active_only:
+            conditions.append("released_at IS NULL")
+        if conditions:
+            parts.append("WHERE " + " AND ".join(conditions))
+        parts.append("ORDER BY assigned_at DESC")
+
+        rows = await _sql.execute_query(" ".join(parts), tuple(params))
+        return [
+            EquipmentAssignment(
+                id=r["id"],
+                asset_id=r["asset_id"],
+                task_id=r["task_id"],
+                assignee=r["assignee"],
+                assignment_type=r["assignment_type"],
+                assigned_at=r["assigned_at"].isoformat() if r["assigned_at"] else None,
+                released_at=r["released_at"].isoformat() if r["released_at"] else None,
+                notes=r["notes"],
+            )
+            for r in rows
+        ]
+    except Exception as exc:
+        logger.error("Failed to list equipment assignments: %s", exc)
+        raise HTTPException(
+            status_code=500,
+            detail=f"Failed to retrieve equipment assignments: {exc}",
+        )
+
+
+@router.get("/equipment/maintenance/schedule", response_model=List[MaintenanceRecord])
+async def get_maintenance_schedule(
+    asset_id: Optional[str] = None,
+    maintenance_type: Optional[str] = None,
+    days_ahead: int = 30,
+    runtime=Depends(get_runtime),
+):
+    """Get upcoming maintenance schedule."""
+    agent = _require_agent(runtime)
+    try:
+        result = await agent.asset_tools.get_maintenance_schedule(
+            asset_id=asset_id,
+            maintenance_type=maintenance_type,
+            days_ahead=days_ahead,
+        )
+        if "error" in result:
+            raise HTTPException(status_code=400, detail=result["error"])
+        return [
+            MaintenanceRecord(
+                id=r["id"],
+                asset_id=r["asset_id"],
+                maintenance_type=r["maintenance_type"],
+                description=r["description"],
+                performed_by=r["performed_by"],
+                performed_at=r["performed_at"],
+                duration_minutes=r["duration_minutes"],
+                cost=r.get("cost"),
+                notes=r.get("notes"),
+            )
+            for r in result.get("maintenance_schedule", [])
+        ]
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.error("Failed to get maintenance schedule: %s", exc)
+        raise HTTPException(
+            status_code=500, detail="Failed to retrieve maintenance schedule"
+        )
+
+
+@router.get("/equipment/{asset_id}", response_model=EquipmentAsset)
+async def get_equipment_by_id(asset_id: str):
+    """Get a single equipment asset by ID."""
+    try:
+        await _sql.initialize()
+        rows = await _sql.execute_query(
+            """
+            SELECT asset_id, type, model, zone, status, owner_user,
+                   next_pm_due, last_maintenance, created_at, updated_at, metadata
+            FROM equipment_assets WHERE asset_id = $1
+            """,
+            (asset_id,),
+        )
+        if not rows:
+            raise HTTPException(
+                status_code=404, detail=f"Equipment asset {asset_id} not found"
+            )
+        return _row_to_asset(rows[0])
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.error("Failed to get equipment %s: %s", asset_id, exc)
+        raise HTTPException(
+            status_code=500, detail="Failed to retrieve equipment asset"
+        )
+
+
+@router.get("/equipment/{asset_id}/telemetry", response_model=List[EquipmentTelemetry])
+async def get_equipment_telemetry(
+    asset_id: str,
+    metric: Optional[str] = None,
+    hours_back: int = 168,
+    runtime=Depends(get_runtime),
+):
+    """Get equipment telemetry from asset tools."""
+    agent = _require_agent(runtime)
+    try:
+        result = await agent.asset_tools.get_equipment_telemetry(
+            asset_id=asset_id, metric=metric, hours_back=hours_back
+        )
+        if "error" in result:
+            raise HTTPException(status_code=400, detail=result["error"])
+        return [
+            EquipmentTelemetry(
+                timestamp=dp["timestamp"],
+                asset_id=dp["asset_id"],
+                metric=dp["metric"],
+                value=dp["value"],
+                unit=dp["unit"],
+                quality_score=dp["quality_score"],
+            )
+            for dp in result.get("telemetry_data", [])
+        ]
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.error("Failed to get telemetry for %s: %s", asset_id, exc)
+        raise HTTPException(status_code=500, detail="Failed to retrieve telemetry data")
+
+
+# ── State-aware read (agent + state provider) ─────────────────────────────────
+
+
+@router.get("/equipment/{asset_id}/status", response_model=Dict[str, Any])
+async def get_equipment_status(asset_id: str, runtime=Depends(get_runtime)):
+    """
+    Get live equipment status including a WarehouseState snapshot.
+
+    Read-only: uses the canonical state pipeline (STATE phase only).
+    The ``state_snapshot`` block is present when the MCP equipment server
+    is configured; omitted otherwise.
+    """
+    agent = _require_agent(runtime)
+    try:
+        state_context = await agent.get_equipment_state_snapshot(asset_id=asset_id)
+        status_result = await agent.asset_tools.get_equipment_status(asset_id=asset_id)
+        telemetry_result = await agent.asset_tools.get_equipment_telemetry(
+            asset_id=asset_id, hours_back=1
+        )
+        response: Dict[str, Any] = {
+            "equipment_status": status_result,
+            "telemetry_data": telemetry_result,
+            "timestamp": datetime.now().isoformat(),
+        }
+        if state_context:
+            response["state_snapshot"] = state_context
+        return response
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.error("Failed to get equipment status for %s: %s", asset_id, exc)
+        raise HTTPException(
+            status_code=500, detail="Failed to retrieve equipment status"
+        )
+
+
+# ── Write endpoints (full pipeline: PROPOSE → DECIDE → EXECUTE) ───────────────
+
+
+@router.post("/equipment/assign", response_model=Dict[str, Any])
+async def assign_equipment(request: AssignmentRequest, runtime=Depends(get_runtime)):
+    """
+    Propose an equipment assignment through the canonical pipeline.
+
+    Response shape::
+
+        {
+            "status": "requires_human_approval" | "approved" | "rejected"
+                      | "requires_fresh_state" | "error",
+            "action": "warehouse.equipment.assign",
+            "proposal_id": "<uuid>",
+            "decision_id": "<uuid>",
+            "reason": "<explanation>",
+            "executed": false | true,
+        }
+    """
+    agent = _require_agent(runtime)
+    try:
+        result = await agent.propose_equipment_assignment(
+            asset_id=request.asset_id,
+            assignee=request.assignee,
+            assignment_type=request.assignment_type,
+            task_id=request.task_id,
+            duration_hours=(
+                float(request.duration_hours) if request.duration_hours else None
+            ),
+            notes=request.notes,
+            warehouse_id=request.warehouse_id or "default",
+        )
+        if result.get("status") == "error":
+            raise HTTPException(
+                status_code=400,
+                detail=result.get("reason", "Assignment proposal failed"),
+            )
+        return result
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.error("Failed to propose assignment for %s: %s", request.asset_id, exc)
+        raise HTTPException(
+            status_code=500, detail="Failed to process assignment proposal"
+        )
+
+
+@router.post("/equipment/release", response_model=Dict[str, Any])
+async def release_equipment(request: ReleaseRequest, runtime=Depends(get_runtime)):
+    """
+    Propose and (if approved) execute releasing equipment from its current assignment.
+
+    LOW risk: DecisionEngine auto-approves unless equipment state is stale/absent.
+    """
+    agent = _require_agent(runtime)
+    try:
+        result = await agent.propose_equipment_release(
+            asset_id=request.asset_id,
+            released_by=request.released_by,
+            notes=request.notes,
+            warehouse_id=request.warehouse_id or "default",
+        )
+        if result.get("status") == "error":
+            raise HTTPException(
+                status_code=400,
+                detail=result.get("reason", "Release failed"),
+            )
+        return result
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.error("Failed to release equipment %s: %s", request.asset_id, exc)
+        raise HTTPException(status_code=500, detail="Failed to release equipment")
+
+
+@router.post("/equipment/maintenance", response_model=Dict[str, Any])
+async def schedule_maintenance(
+    request: MaintenanceRequest, runtime=Depends(get_runtime)
+):
+    """
+    Propose scheduling maintenance for equipment.
+
+    MEDIUM risk: DecisionEngine always returns requires_human_approval.
+    """
+    agent = _require_agent(runtime)
+    try:
+        result = await agent.propose_schedule_maintenance(
+            asset_id=request.asset_id,
+            maintenance_type=request.maintenance_type,
+            description=request.description,
+            scheduled_by=request.scheduled_by,
+            scheduled_for=request.scheduled_for,
+            estimated_duration_minutes=request.estimated_duration_minutes,
+            priority=request.priority,
+            warehouse_id=request.warehouse_id or "default",
+        )
+        if result.get("status") == "error":
+            raise HTTPException(
+                status_code=400,
+                detail=result.get("reason", "Maintenance scheduling failed"),
+            )
+        return result
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.error("Failed to schedule maintenance for %s: %s", request.asset_id, exc)
+        raise HTTPException(status_code=500, detail="Failed to schedule maintenance")

--- a/apps/api/maiw_api/routers/health.py
+++ b/apps/api/maiw_api/routers/health.py
@@ -1,0 +1,263 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""
+Health router — Batch B.
+
+Endpoints preserved from src/api/routers/health.py:
+    GET /api/v1/live             — liveness probe
+    GET /api/v1/ready            — readiness probe (checks DB)
+    GET /api/v1/health           — comprehensive health (DB + Redis + Milvus)
+    GET /api/v1/health/simple    — lightweight health for frontend
+    GET /api/v1/version          — version info
+    GET /api/v1/version/detailed — detailed build info
+
+Changes from src/ version:
+    - Adds MAIW runtime status block to /health response
+    - Imports runtime via FastAPI Depends rather than a module-level import
+    - Uses src.api.services.version for version info (unchanged)
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from datetime import datetime
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+
+from maiw_api.dependencies import get_runtime
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/v1", tags=["Health"])
+
+_start_time = datetime.utcnow()
+
+
+def _uptime() -> str:
+    total = int((datetime.utcnow() - _start_time).total_seconds())
+    d, rem = divmod(total, 86400)
+    h, rem = divmod(rem, 3600)
+    m, s = divmod(rem, 60)
+    if d:
+        return f"{d}d {h}h {m}m {s}s"
+    if h:
+        return f"{h}h {m}m {s}s"
+    if m:
+        return f"{m}m {s}s"
+    return f"{s}s"
+
+
+async def _check_database() -> dict:
+    try:
+        import asyncpg
+        from dotenv import load_dotenv
+
+        load_dotenv()
+        url = os.getenv(
+            "DATABASE_URL",
+            "postgresql://{user}:{pw}@localhost:5435/{db}".format(
+                user=os.getenv("POSTGRES_USER", "warehouse"),
+                pw=os.getenv("POSTGRES_PASSWORD", ""),
+                db=os.getenv("POSTGRES_DB", "warehouse"),
+            ),
+        )
+        conn = await asyncpg.connect(url)
+        await conn.execute("SELECT 1")
+        await conn.close()
+        return {"status": "healthy", "message": "Database connection successful"}
+    except Exception as exc:
+        logger.error("Database health check failed: %s", exc)
+        return {"status": "unhealthy", "message": str(exc)}
+
+
+async def _check_redis() -> dict:
+    try:
+        import redis
+
+        client = redis.Redis(
+            host=os.getenv("REDIS_HOST", "localhost"),
+            port=int(os.getenv("REDIS_PORT", "6379")),
+        )
+        client.ping()
+        return {"status": "healthy", "message": "Redis connection successful"}
+    except Exception as exc:
+        logger.warning("Redis health check failed: %s", exc)
+        return {"status": "unhealthy", "message": str(exc)}
+
+
+async def _check_milvus() -> dict:
+    try:
+        from pymilvus import connections, utility
+
+        connections.connect(
+            alias="default",
+            host=os.getenv("MILVUS_HOST", "localhost"),
+            port=os.getenv("MILVUS_PORT", "19530"),
+        )
+        utility.get_server_version()
+        return {"status": "healthy", "message": "Milvus connection successful"}
+    except Exception as exc:
+        logger.warning("Milvus health check failed: %s", exc)
+        return {"status": "unhealthy", "message": str(exc)}
+
+
+def _version_display() -> str:
+    try:
+        from src.api.services.version import version_service
+
+        return version_service.get_version_display()
+    except Exception:
+        return "0.0.0-dev"
+
+
+@router.get("/live")
+async def liveness_check():
+    return {
+        "status": "alive",
+        "timestamp": datetime.utcnow().isoformat(),
+        "uptime": _uptime(),
+        "version": _version_display(),
+    }
+
+
+@router.get("/ready")
+async def readiness_check():
+    db = await _check_database()
+    if db["status"] != "healthy":
+        raise HTTPException(
+            status_code=503, detail="Service not ready: Database unavailable"
+        )
+    return {
+        "status": "ready",
+        "timestamp": datetime.utcnow().isoformat(),
+        "version": _version_display(),
+    }
+
+
+@router.get("/health/simple")
+async def health_simple():
+    try:
+        import asyncpg
+        from dotenv import load_dotenv
+
+        load_dotenv()
+        url = os.getenv(
+            "DATABASE_URL",
+            "postgresql://{user}:{pw}@localhost:5435/{db}".format(
+                user=os.getenv("POSTGRES_USER", "warehouse"),
+                pw=os.getenv("POSTGRES_PASSWORD", ""),
+                db=os.getenv("POSTGRES_DB", "warehouse"),
+            ),
+        )
+        conn = await asyncpg.connect(url)
+        await conn.execute("SELECT 1")
+        await conn.close()
+        return {"ok": True, "status": "healthy"}
+    except Exception as exc:
+        logger.error("Simple health check failed: %s", exc)
+        return {"ok": False, "status": "unhealthy", "error": str(exc)}
+
+
+@router.get("/health")
+async def health_check(request: Request):
+    runtime = request.app.state.runtime
+
+    data: dict = {
+        "status": "healthy",
+        "timestamp": datetime.utcnow().isoformat(),
+        "uptime": _uptime(),
+        "version": _version_display(),
+        "environment": os.getenv("ENVIRONMENT", "development"),
+    }
+
+    services: dict = {}
+    for name, coro in [
+        ("database", _check_database()),
+        ("redis", _check_redis()),
+        ("milvus", _check_milvus()),
+    ]:
+        try:
+            services[name] = await coro
+        except Exception as exc:
+            services[name] = {"status": "error", "message": str(exc)}
+
+    # MAIW runtime status
+    if runtime is not None:
+        data["maiw_runtime"] = {
+            "equipment_agent": runtime.equipment_agent is not None,
+            "operations_agent": runtime.operations_agent is not None,
+            "safety_agent": runtime.safety_agent is not None,
+            "mcp_inventory": runtime.mcp_inventory_available,
+            "mcp_equipment": runtime.mcp_equipment_available,
+            "mcp_labor": runtime.mcp_labor_available,
+            "mcp_wave": runtime.mcp_wave_available,
+        }
+
+    data["services"] = services
+
+    unhealthy = [
+        n for n, s in services.items() if s.get("status") in ("unhealthy", "error")
+    ]
+    if unhealthy:
+        data["status"] = "degraded"
+        data["unhealthy_services"] = unhealthy
+
+    return data
+
+
+@router.get("/version")
+async def get_version():
+    _fallback = {
+        "status": "ok",
+        "version": "0.0.0-dev",
+        "git_sha": "unknown",
+        "build_time": datetime.utcnow().isoformat(),
+        "environment": os.getenv("ENVIRONMENT", "development"),
+    }
+    try:
+        from src.api.services.version import version_service
+
+        info = await asyncio.wait_for(
+            asyncio.to_thread(version_service.get_version_info),
+            timeout=2.0,
+        )
+        return {"status": "ok", **info}
+    except asyncio.TimeoutError:
+        logger.warning("Version service timed out")
+        return _fallback
+    except Exception as exc:
+        logger.error("Version endpoint failed: %s", exc)
+        return _fallback
+
+
+@router.get("/version/detailed")
+async def get_detailed_version():
+    _fallback = {
+        "status": "ok",
+        "version": "0.0.0-dev",
+        "git_sha": "unknown",
+        "git_branch": "unknown",
+        "build_time": datetime.utcnow().isoformat(),
+        "commit_count": 0,
+        "python_version": "unknown",
+        "environment": os.getenv("ENVIRONMENT", "development"),
+        "docker_image": "unknown",
+        "build_host": os.getenv("HOSTNAME", "unknown"),
+        "build_user": os.getenv("USER", "unknown"),
+    }
+    try:
+        from src.api.services.version import version_service
+
+        info = await asyncio.wait_for(
+            asyncio.to_thread(version_service.get_detailed_info),
+            timeout=3.0,
+        )
+        return {"status": "ok", **info}
+    except asyncio.TimeoutError:
+        logger.warning("Detailed version service timed out")
+        return _fallback
+    except Exception as exc:
+        logger.error("Detailed version endpoint failed: %s", exc)
+        return _fallback

--- a/apps/api/maiw_api/routers/mcp_status.py
+++ b/apps/api/maiw_api/routers/mcp_status.py
@@ -1,0 +1,110 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""
+MCP Status router — Batch E.
+
+Replaces src/api/routers/mcp.py (legacy custom MCP system) with a canonical
+MCP v2 status endpoint.
+
+The legacy router imported:
+    ToolDiscoveryService, ToolBindingService, ToolRoutingService,
+    mcp_integrated_planner_graph — all retired.
+
+This router exposes:
+    GET /api/v1/mcp/status
+        Current capability registry state and domain availability flags.
+    GET /api/v1/mcp/capabilities
+        List of all registered capability names.
+
+No write endpoints — the MCP layer is invoked by agents through the
+canonical pipeline, not directly by REST callers.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, List
+
+from fastapi import APIRouter, Depends
+
+from maiw_api.dependencies import get_runtime
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/v1/mcp", tags=["MCP"])
+
+
+@router.get("/status", response_model=Dict[str, Any])
+async def get_mcp_status(runtime=Depends(get_runtime)):
+    """
+    Return the current state of the MCP CapabilityRegistry.
+
+    Response::
+
+        {
+            "protocol": "MCP 2026-07-28",
+            "client_ready": true,
+            "domains": {
+                "inventory":  { "available": true,  "url": "http://..." },
+                "equipment":  { "available": false, "url": null },
+                "labor":      { "available": false, "url": null },
+                "wave":       { "available": false, "url": null },
+            },
+            "registered_capabilities": ["warehouse.inventory.get", ...],
+        }
+    """
+    registry = getattr(runtime, "mcp_registry", None)
+
+    capabilities: List[str] = []
+    if registry is not None:
+        try:
+            capabilities = registry.all_capabilities()
+        except Exception:
+            pass
+
+    def _url_for(domain: str) -> str | None:
+        if registry is None:
+            return None
+        for cap in capabilities:
+            if cap.startswith(f"warehouse.{domain}."):
+                try:
+                    return registry.resolve(cap)
+                except Exception:
+                    pass
+        return None
+
+    return {
+        "protocol": "MCP 2026-07-28",
+        "client_ready": runtime.mcp_client is not None,
+        "domains": {
+            "inventory": {
+                "available": runtime.mcp_inventory_available,
+                "url": _url_for("inventory"),
+            },
+            "equipment": {
+                "available": runtime.mcp_equipment_available,
+                "url": _url_for("equipment"),
+            },
+            "labor": {
+                "available": runtime.mcp_labor_available,
+                "url": _url_for("labor"),
+            },
+            "wave": {
+                "available": runtime.mcp_wave_available,
+                "url": _url_for("wave"),
+            },
+        },
+        "registered_capabilities": capabilities,
+    }
+
+
+@router.get("/capabilities", response_model=List[str])
+async def list_capabilities(runtime=Depends(get_runtime)):
+    """List all registered MCP capability names."""
+    registry = getattr(runtime, "mcp_registry", None)
+    if registry is None:
+        return []
+    try:
+        return registry.all_capabilities()
+    except Exception:
+        return []

--- a/apps/api/maiw_api/routers/operations.py
+++ b/apps/api/maiw_api/routers/operations.py
@@ -1,0 +1,231 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""
+Operations router — Batch D.
+
+All task CRUD endpoints use SQLRetriever directly — no canonical agent needed
+for CRUD operations.  The canonical OperationsCoordinationAgent is a reasoning
+agent that processes natural-language queries and is wired into the chat router.
+
+Bug fixed from src/api/routers/operations.py:
+    PUT /operations/tasks/{task_id} referenced undefined ``task_queries``.
+    Fixed to use ``TaskQueries()``.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import List, Optional
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+
+from src.retrieval.structured import SQLRetriever, TaskQueries
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/v1", tags=["Operations"])
+
+_sql = SQLRetriever()
+_task_queries = TaskQueries()
+
+
+class Task(BaseModel):
+    id: int
+    kind: str
+    status: str
+    assignee: Optional[str] = None
+    payload: dict
+    created_at: str
+    updated_at: str
+
+
+class TaskCreate(BaseModel):
+    kind: str
+    status: str = "pending"
+    assignee: Optional[str] = None
+    payload: dict = {}
+
+
+class TaskUpdate(BaseModel):
+    status: Optional[str] = None
+    assignee: Optional[str] = None
+    payload: Optional[dict] = None
+
+
+class WorkforceStatus(BaseModel):
+    total_workers: int
+    active_workers: int
+    available_workers: int
+    tasks_in_progress: int
+    tasks_pending: int
+
+
+def _parse_payload(raw) -> dict:
+    if isinstance(raw, dict):
+        return raw
+    if isinstance(raw, str):
+        try:
+            return json.loads(raw)
+        except json.JSONDecodeError:
+            return {}
+    return {}
+
+
+def _row_to_task(row: dict) -> Task:
+    return Task(
+        id=row["id"],
+        kind=row["kind"],
+        status=row["status"],
+        assignee=row["assignee"],
+        payload=_parse_payload(row["payload"]),
+        created_at=row["created_at"].isoformat() if row["created_at"] else "",
+        updated_at=row["updated_at"].isoformat() if row["updated_at"] else "",
+    )
+
+
+@router.get("/operations/tasks", response_model=List[Task])
+async def get_tasks():
+    """List all tasks ordered by creation time."""
+    try:
+        await _sql.initialize()
+        rows = await _sql.fetch_all(
+            "SELECT id, kind, status, assignee, payload, created_at, updated_at "
+            "FROM tasks ORDER BY created_at DESC"
+        )
+        return [_row_to_task(r) for r in rows]
+    except Exception as exc:
+        logger.error("Failed to get tasks: %s", exc)
+        raise HTTPException(status_code=500, detail="Failed to retrieve tasks")
+
+
+@router.get("/operations/tasks/{task_id}", response_model=Task)
+async def get_task(task_id: int):
+    """Get a specific task by ID."""
+    try:
+        await _sql.initialize()
+        task = await _task_queries.get_task_by_id(_sql, task_id)
+        if not task:
+            raise HTTPException(status_code=404, detail=f"Task {task_id} not found")
+        return _row_to_task(task)
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.error("Failed to get task %s: %s", task_id, exc)
+        raise HTTPException(status_code=500, detail="Failed to retrieve task")
+
+
+@router.post("/operations/tasks", response_model=Task)
+async def create_task(task: TaskCreate):
+    """Create a new task."""
+    try:
+        await _sql.initialize()
+        result = await _sql.fetch_one(
+            """
+            INSERT INTO tasks (kind, status, assignee, payload, created_at, updated_at)
+            VALUES ($1, $2, $3, $4, NOW(), NOW())
+            RETURNING id, kind, status, assignee, payload, created_at, updated_at
+            """,
+            task.kind,
+            task.status,
+            task.assignee,
+            json.dumps(task.payload),
+        )
+        return _row_to_task(result)
+    except Exception as exc:
+        logger.error("Failed to create task: %s", exc)
+        raise HTTPException(status_code=500, detail="Failed to create task")
+
+
+@router.put("/operations/tasks/{task_id}", response_model=Task)
+async def update_task(task_id: int, update: TaskUpdate):
+    """Update status, assignee, or payload of an existing task."""
+    try:
+        await _sql.initialize()
+        current = await _task_queries.get_task_by_id(_sql, task_id)
+        if not current:
+            raise HTTPException(status_code=404, detail=f"Task {task_id} not found")
+
+        new_status = update.status if update.status is not None else current["status"]
+        new_assignee = (
+            update.assignee if update.assignee is not None else current["assignee"]
+        )
+        new_payload = (
+            update.payload if update.payload is not None else current["payload"]
+        )
+        if isinstance(new_payload, dict):
+            new_payload = json.dumps(new_payload)
+        elif new_payload is None:
+            new_payload = json.dumps({})
+
+        result = await _sql.fetch_one(
+            """
+            UPDATE tasks
+            SET status = $1, assignee = $2, payload = $3, updated_at = NOW()
+            WHERE id = $4
+            RETURNING id, kind, status, assignee, payload, created_at, updated_at
+            """,
+            new_status,
+            new_assignee,
+            new_payload,
+            task_id,
+        )
+        return _row_to_task(result)
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.error("Failed to update task %s: %s", task_id, exc)
+        raise HTTPException(status_code=500, detail="Failed to update task")
+
+
+@router.post("/operations/tasks/{task_id}/assign")
+async def assign_task(task_id: int, assignee: str):
+    """Assign a task to a worker."""
+    try:
+        await _sql.initialize()
+        await _task_queries.assign_task(_sql, task_id, assignee)
+        task = await _task_queries.get_task_by_id(_sql, task_id)
+        return _row_to_task(task)
+    except Exception as exc:
+        logger.error("Failed to assign task %s: %s", task_id, exc)
+        raise HTTPException(status_code=500, detail="Failed to assign task")
+
+
+@router.get("/operations/workforce", response_model=WorkforceStatus)
+async def get_workforce_status():
+    """Get aggregate workforce and task statistics."""
+    try:
+        await _sql.initialize()
+
+        task_stats = await _sql.fetch_one("""
+            SELECT
+                COUNT(*) AS total_tasks,
+                COUNT(CASE WHEN status = 'in_progress' THEN 1 END) AS in_progress,
+                COUNT(CASE WHEN status = 'pending' THEN 1 END) AS pending
+            FROM tasks
+            """)
+        user_stats = await _sql.fetch_one("""
+            SELECT
+                COUNT(*) AS total_users,
+                COUNT(CASE WHEN status = 'active' THEN 1 END) AS active_users,
+                COUNT(CASE WHEN role IN ('operator', 'supervisor', 'manager')
+                           AND status = 'active' THEN 1 END) AS operational_workers
+            FROM users
+            """)
+
+        operational = user_stats.get("operational_workers") or 0
+        in_progress = task_stats["in_progress"] or 0
+
+        return WorkforceStatus(
+            total_workers=user_stats.get("total_users") or 0,
+            active_workers=user_stats.get("active_users") or 0,
+            available_workers=max(0, operational - in_progress),
+            tasks_in_progress=in_progress,
+            tasks_pending=task_stats["pending"] or 0,
+        )
+    except Exception as exc:
+        logger.error("Failed to get workforce status: %s", exc)
+        raise HTTPException(
+            status_code=500, detail="Failed to retrieve workforce status"
+        )

--- a/apps/api/maiw_api/routers/operations.py
+++ b/apps/api/maiw_api/routers/operations.py
@@ -21,14 +21,30 @@ from typing import List, Optional
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 
-from src.retrieval.structured import SQLRetriever, TaskQueries
-
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/v1", tags=["Operations"])
 
-_sql = SQLRetriever()
-_task_queries = TaskQueries()
+_sql = None
+_task_queries = None
+
+
+def _get_sql():
+    global _sql
+    if _sql is None:
+        from src.retrieval.structured import SQLRetriever
+
+        _sql = SQLRetriever()
+    return _sql
+
+
+def _get_task_queries():
+    global _task_queries
+    if _task_queries is None:
+        from src.retrieval.structured import TaskQueries
+
+        _task_queries = TaskQueries()
+    return _task_queries
 
 
 class Task(BaseModel):
@@ -89,8 +105,9 @@ def _row_to_task(row: dict) -> Task:
 async def get_tasks():
     """List all tasks ordered by creation time."""
     try:
-        await _sql.initialize()
-        rows = await _sql.fetch_all(
+        sql = _get_sql()
+        await sql.initialize()
+        rows = await sql.fetch_all(
             "SELECT id, kind, status, assignee, payload, created_at, updated_at "
             "FROM tasks ORDER BY created_at DESC"
         )
@@ -104,8 +121,9 @@ async def get_tasks():
 async def get_task(task_id: int):
     """Get a specific task by ID."""
     try:
-        await _sql.initialize()
-        task = await _task_queries.get_task_by_id(_sql, task_id)
+        sql = _get_sql()
+        await sql.initialize()
+        task = await _get_task_queries().get_task_by_id(sql, task_id)
         if not task:
             raise HTTPException(status_code=404, detail=f"Task {task_id} not found")
         return _row_to_task(task)
@@ -120,8 +138,9 @@ async def get_task(task_id: int):
 async def create_task(task: TaskCreate):
     """Create a new task."""
     try:
-        await _sql.initialize()
-        result = await _sql.fetch_one(
+        sql = _get_sql()
+        await sql.initialize()
+        result = await sql.fetch_one(
             """
             INSERT INTO tasks (kind, status, assignee, payload, created_at, updated_at)
             VALUES ($1, $2, $3, $4, NOW(), NOW())
@@ -142,8 +161,9 @@ async def create_task(task: TaskCreate):
 async def update_task(task_id: int, update: TaskUpdate):
     """Update status, assignee, or payload of an existing task."""
     try:
-        await _sql.initialize()
-        current = await _task_queries.get_task_by_id(_sql, task_id)
+        sql = _get_sql()
+        await sql.initialize()
+        current = await _get_task_queries().get_task_by_id(sql, task_id)
         if not current:
             raise HTTPException(status_code=404, detail=f"Task {task_id} not found")
 
@@ -159,7 +179,7 @@ async def update_task(task_id: int, update: TaskUpdate):
         elif new_payload is None:
             new_payload = json.dumps({})
 
-        result = await _sql.fetch_one(
+        result = await sql.fetch_one(
             """
             UPDATE tasks
             SET status = $1, assignee = $2, payload = $3, updated_at = NOW()
@@ -183,9 +203,11 @@ async def update_task(task_id: int, update: TaskUpdate):
 async def assign_task(task_id: int, assignee: str):
     """Assign a task to a worker."""
     try:
-        await _sql.initialize()
-        await _task_queries.assign_task(_sql, task_id, assignee)
-        task = await _task_queries.get_task_by_id(_sql, task_id)
+        sql = _get_sql()
+        await sql.initialize()
+        tq = _get_task_queries()
+        await tq.assign_task(sql, task_id, assignee)
+        task = await tq.get_task_by_id(sql, task_id)
         return _row_to_task(task)
     except Exception as exc:
         logger.error("Failed to assign task %s: %s", task_id, exc)
@@ -196,16 +218,17 @@ async def assign_task(task_id: int, assignee: str):
 async def get_workforce_status():
     """Get aggregate workforce and task statistics."""
     try:
-        await _sql.initialize()
+        sql = _get_sql()
+        await sql.initialize()
 
-        task_stats = await _sql.fetch_one("""
+        task_stats = await sql.fetch_one("""
             SELECT
                 COUNT(*) AS total_tasks,
                 COUNT(CASE WHEN status = 'in_progress' THEN 1 END) AS in_progress,
                 COUNT(CASE WHEN status = 'pending' THEN 1 END) AS pending
             FROM tasks
             """)
-        user_stats = await _sql.fetch_one("""
+        user_stats = await sql.fetch_one("""
             SELECT
                 COUNT(*) AS total_users,
                 COUNT(CASE WHEN status = 'active' THEN 1 END) AS active_users,

--- a/apps/api/maiw_api/routers/safety.py
+++ b/apps/api/maiw_api/routers/safety.py
@@ -17,13 +17,20 @@ from typing import List, Optional
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 
-from src.retrieval.structured import SQLRetriever
-
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/v1", tags=["Safety"])
 
-_sql = SQLRetriever()
+_sql = None
+
+
+def _get_sql():
+    global _sql
+    if _sql is None:
+        from src.retrieval.structured import SQLRetriever
+
+        _sql = SQLRetriever()
+    return _sql
 
 
 class SafetyIncident(BaseModel):
@@ -97,8 +104,9 @@ _POLICIES: List[SafetyPolicy] = [
 async def get_incidents():
     """List all safety incidents ordered by occurrence time."""
     try:
-        await _sql.initialize()
-        rows = await _sql.fetch_all(
+        sql = _get_sql()
+        await sql.initialize()
+        rows = await sql.fetch_all(
             "SELECT id, severity, description, reported_by, occurred_at "
             "FROM safety_incidents ORDER BY occurred_at DESC"
         )
@@ -123,8 +131,9 @@ async def get_incidents():
 async def get_incident(incident_id: int):
     """Get a specific safety incident by ID."""
     try:
-        await _sql.initialize()
-        row = await _sql.fetch_one(
+        sql = _get_sql()
+        await sql.initialize()
+        row = await sql.fetch_one(
             "SELECT id, severity, description, reported_by, occurred_at "
             "FROM safety_incidents WHERE id = $1",
             incident_id,
@@ -154,8 +163,9 @@ async def get_incident(incident_id: int):
 async def create_incident(incident: SafetyIncidentCreate):
     """Create a new safety incident record."""
     try:
-        await _sql.initialize()
-        result = await _sql.fetch_one(
+        sql = _get_sql()
+        await sql.initialize()
+        result = await sql.fetch_one(
             """
             INSERT INTO safety_incidents (severity, description, reported_by, occurred_at)
             VALUES ($1, $2, $3, NOW())

--- a/apps/api/maiw_api/routers/safety.py
+++ b/apps/api/maiw_api/routers/safety.py
@@ -1,0 +1,194 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""
+Safety router — Batch D.
+
+Incident CRUD uses SQLRetriever directly.  The canonical SafetyComplianceAgent
+is a reasoning agent wired into the chat router — it is not used for CRUD.
+
+Policies are static reference data (no DB table) — preserved as-is from src/.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import List, Optional
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+
+from src.retrieval.structured import SQLRetriever
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/v1", tags=["Safety"])
+
+_sql = SQLRetriever()
+
+
+class SafetyIncident(BaseModel):
+    id: int
+    severity: str
+    description: str
+    reported_by: str
+    occurred_at: str
+
+
+class SafetyIncidentCreate(BaseModel):
+    severity: str
+    description: str
+    reported_by: str
+
+
+class SafetyPolicy(BaseModel):
+    id: str
+    name: str
+    category: str
+    last_updated: str
+    status: str
+    summary: str
+
+
+_POLICIES: List[SafetyPolicy] = [
+    SafetyPolicy(
+        id="POL-001",
+        name="Personal Protective Equipment (PPE) Policy",
+        category="Safety Equipment",
+        last_updated="2024-01-15",
+        status="Active",
+        summary="All personnel must wear appropriate PPE in designated areas",
+    ),
+    SafetyPolicy(
+        id="POL-002",
+        name="Forklift Operation Safety Guidelines",
+        category="Equipment Safety",
+        last_updated="2024-01-10",
+        status="Active",
+        summary="Comprehensive guidelines for safe forklift operation",
+    ),
+    SafetyPolicy(
+        id="POL-003",
+        name="Emergency Evacuation Procedures",
+        category="Emergency Response",
+        last_updated="2024-01-05",
+        status="Active",
+        summary="Step-by-step emergency evacuation procedures",
+    ),
+    SafetyPolicy(
+        id="POL-004",
+        name="Chemical Handling Safety Protocol",
+        category="Chemical Safety",
+        last_updated="2024-01-12",
+        status="Active",
+        summary="Safe handling and storage procedures for chemicals",
+    ),
+    SafetyPolicy(
+        id="POL-005",
+        name="Ladder and Elevated Work Safety",
+        category="Fall Prevention",
+        last_updated="2024-01-08",
+        status="Active",
+        summary="Safety requirements for working at heights",
+    ),
+]
+
+
+@router.get("/safety/incidents", response_model=List[SafetyIncident])
+async def get_incidents():
+    """List all safety incidents ordered by occurrence time."""
+    try:
+        await _sql.initialize()
+        rows = await _sql.fetch_all(
+            "SELECT id, severity, description, reported_by, occurred_at "
+            "FROM safety_incidents ORDER BY occurred_at DESC"
+        )
+        return [
+            SafetyIncident(
+                id=r["id"],
+                severity=r["severity"],
+                description=r["description"],
+                reported_by=r["reported_by"],
+                occurred_at=r["occurred_at"].isoformat() if r["occurred_at"] else "",
+            )
+            for r in rows
+        ]
+    except Exception as exc:
+        logger.error("Failed to get safety incidents: %s", exc)
+        raise HTTPException(
+            status_code=500, detail="Failed to retrieve safety incidents"
+        )
+
+
+@router.get("/safety/incidents/{incident_id}", response_model=SafetyIncident)
+async def get_incident(incident_id: int):
+    """Get a specific safety incident by ID."""
+    try:
+        await _sql.initialize()
+        row = await _sql.fetch_one(
+            "SELECT id, severity, description, reported_by, occurred_at "
+            "FROM safety_incidents WHERE id = $1",
+            incident_id,
+        )
+        if not row:
+            raise HTTPException(
+                status_code=404,
+                detail=f"Safety incident {incident_id} not found",
+            )
+        return SafetyIncident(
+            id=row["id"],
+            severity=row["severity"],
+            description=row["description"],
+            reported_by=row["reported_by"],
+            occurred_at=row["occurred_at"].isoformat() if row["occurred_at"] else "",
+        )
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.error("Failed to get safety incident %s: %s", incident_id, exc)
+        raise HTTPException(
+            status_code=500, detail="Failed to retrieve safety incident"
+        )
+
+
+@router.post("/safety/incidents", response_model=SafetyIncident)
+async def create_incident(incident: SafetyIncidentCreate):
+    """Create a new safety incident record."""
+    try:
+        await _sql.initialize()
+        result = await _sql.fetch_one(
+            """
+            INSERT INTO safety_incidents (severity, description, reported_by, occurred_at)
+            VALUES ($1, $2, $3, NOW())
+            RETURNING id, severity, description, reported_by, occurred_at
+            """,
+            incident.severity,
+            incident.description,
+            incident.reported_by,
+        )
+        return SafetyIncident(
+            id=result["id"],
+            severity=result["severity"],
+            description=result["description"],
+            reported_by=result["reported_by"],
+            occurred_at=(
+                result["occurred_at"].isoformat() if result["occurred_at"] else ""
+            ),
+        )
+    except Exception as exc:
+        logger.error("Failed to create safety incident: %s", exc)
+        raise HTTPException(status_code=500, detail="Failed to create safety incident")
+
+
+@router.get("/safety/policies", response_model=List[SafetyPolicy])
+async def get_policies():
+    """List all safety policies (static reference data)."""
+    return _POLICIES
+
+
+@router.get("/safety/policies/{policy_id}", response_model=SafetyPolicy)
+async def get_policy(policy_id: str):
+    """Get a specific safety policy by ID."""
+    for policy in _POLICIES:
+        if policy.id == policy_id:
+            return policy
+    raise HTTPException(status_code=404, detail=f"Safety policy {policy_id} not found")

--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -17,6 +17,8 @@ dependencies = [
     "maiw-state>=0.1.0",
     "maiw-decision>=0.1.0",
     "maiw-mcp>=0.1.0",
+    "maiw-execution>=0.1.0",
+    "maiw-agents>=0.1.0",
 ]
 
 [tool.setuptools.packages.find]

--- a/deploy/compose/docker-compose.yaml
+++ b/deploy/compose/docker-compose.yaml
@@ -2,7 +2,7 @@ version: "3.9"
 services:
   chain_server:
     image: python:3.11-slim
-    command: bash -lc "pip install fastapi uvicorn && uvicorn src.api.app:app --host 0.0.0.0 --port 8000"
+    command: bash -lc "pip install fastapi uvicorn && uvicorn maiw_api.app:app --host 0.0.0.0 --port 8000"
     working_dir: /app
     volumes: [".:/app"]
     ports: ["8000:8000"]

--- a/docs/architecture/API_MIGRATION_PLAN.md
+++ b/docs/architecture/API_MIGRATION_PLAN.md
@@ -1,0 +1,183 @@
+# API Migration Plan — Phase 9B
+
+**Status:** IN PROGRESS (Phase 9B)  
+**Branch:** `feat/phase-9b-api-migration`  
+**Entering baseline:** 528 passed, 1 skipped, 0 failed (CORE CI)
+
+---
+
+## Objective
+
+Move the application shell from `src/api/` to `apps/api/maiw_api/` so that
+`apps/api` becomes the canonical FastAPI entrypoint and `MAIWRuntime` becomes
+the canonical composition root.
+
+Canonical packages (`maiw-models`, `maiw-mcp`, `maiw-state`, `maiw-skills`,
+`maiw-decision`, `maiw-execution`, `maiw-agents`) must not depend on the API
+layer. The API layer may depend on all of them.
+
+---
+
+## Ownership Audit
+
+### `apps/api/maiw_api/` — new canonical application layer
+
+| File | Action |
+|------|--------|
+| `bootstrap.py` | REWRITE — fix broken syntax, correct full wiring |
+| `app.py` | CREATE — canonical FastAPI entrypoint |
+| `config.py` | CREATE — application settings |
+| `dependencies.py` | CREATE — FastAPI dependency helpers |
+| `lifespan.py` | CREATE — FastAPI lifespan (startup/shutdown) |
+| `routers/health.py` | CREATE — health, live, ready, version |
+| `routers/equipment.py` | CREATE — canonical equipment (via MAIWRuntime) |
+| `routers/operations.py` | CREATE — operations CRUD + agent |
+| `routers/safety.py` | CREATE — safety CRUD |
+| `routers/mcp_status.py` | CREATE — MCP v2 capability status |
+
+### `src/api/routers/` — classification
+
+| Router | New location | Canonical dependency | Status |
+|--------|-------------|---------------------|--------|
+| `health.py` | `maiw_api.routers.health` | MAIWRuntime | MOVED |
+| `equipment.py` | `maiw_api.routers.equipment` | `maiw_agents.equipment` | MOVED |
+| `operations.py` | `maiw_api.routers.operations` | SQLRetriever / `maiw_agents.operations` | MOVED |
+| `safety.py` | `maiw_api.routers.safety` | SQLRetriever | MOVED |
+| `mcp.py` | `maiw_api.routers.mcp_status` | `maiw_mcp` (canonical) | REPLACED |
+| `chat.py` | imported from `src.api.routers.chat` | LangGraph planner | KEEP TEMPORARILY |
+| `auth.py` | imported from `src.api.routers.auth` | JWT/RBAC | KEEP TEMPORARILY |
+| `inventory.py` | imported from `src.api.routers.inventory` | SQLRetriever | KEEP TEMPORARILY |
+| `wms.py` | imported from `src.api.routers.wms` | WMS integration | INTEGRATION-SPECIFIC |
+| `iot.py` | imported from `src.api.routers.iot` | IoT integration | INTEGRATION-SPECIFIC |
+| `erp.py` | imported from `src.api.routers.erp` | ERP integration | INTEGRATION-SPECIFIC |
+| `scanning.py` | imported from `src.api.routers.scanning` | Scanning integration | INTEGRATION-SPECIFIC |
+| `attendance.py` | imported from `src.api.routers.attendance` | Attendance integration | INTEGRATION-SPECIFIC |
+| `reasoning.py` | imported from `src.api.routers.reasoning` | Reasoning service | KEEP TEMPORARILY |
+| `migration.py` | imported from `src.api.routers.migration` | DB migration | KEEP TEMPORARILY |
+| `document.py` | imported from `src.api.routers.document` | OCR/NeMo pipeline | KEEP TEMPORARILY — DOCUMENT INTEGRATION |
+| `advanced_forecasting.py` | imported from `src.api.routers.advanced_forecasting` | Forecasting | INTEGRATION-SPECIFIC |
+| `training.py` | imported from `src.api.routers.training` | Training (FUTURE) | INTEGRATION-SPECIFIC |
+
+### `src/api/agents/` — classification
+
+| Module | Classification | Reason |
+|--------|---------------|--------|
+| `inventory/equipment_agent.py` | LEGACY — keep during Phase 9B | Called by legacy chat router |
+| `inventory/state_aware_ops.py` | LEGACY — superseded by `maiw_agents.equipment.state_aware_ops` | |
+| `inventory/equipment_asset_tools.py` | ACTIVE INTEGRATION — EquipmentAssetTools → PostgreSQL | Used by canonical agent via bootstrap |
+| `inventory/mcp_equipment_agent.py` | DEPRECATED — old custom MCP agent | No active callers post-migration |
+| `inventory/action_executor.py` | SUPERSEDED — by `maiw_execution` package | |
+| `operations/operations_agent.py` | LEGACY — keep during Phase 9B | Called by chat router |
+| `operations/mcp_operations_agent.py` | DEPRECATED — old custom MCP agent | |
+| `operations/labor_executor.py` | SUPERSEDED — by `maiw_execution.LaborActionExecutor` | |
+| `operations/wave_executor.py` | SUPERSEDED — by `maiw_execution.WaveActionExecutor` | |
+| `safety/safety_agent.py` | LEGACY — keep during Phase 9B | Called by chat router |
+| `safety/mcp_safety_agent.py` | DEPRECATED — old custom MCP agent | |
+| `forecasting/` | INTEGRATION-SPECIFIC — keep as-is | |
+| `document/` | INTEGRATION-SPECIFIC — keep as-is | |
+
+### `src/api/services/` — classification
+
+| Module | Classification | Remove When |
+|--------|---------------|------------|
+| `model_gateway/__init__.py` | COMPATIBILITY SHIM → `maiw_models` | After all callers migrated to `maiw_models` |
+| `model_gateway/*.py` | ACTIVE — original implementation (now in `maiw-models`) | Already shadowed by canonical package |
+| `skills/inventory.py` | COMPATIBILITY SHIM → `maiw_skills` | After callers migrated |
+| `skills/equipment.py` | COMPATIBILITY SHIM → `maiw_skills` | After callers migrated |
+| `skills/labor.py` | COMPATIBILITY SHIM → `maiw_skills` | After callers migrated |
+| `skills/wave.py` | COMPATIBILITY SHIM → `maiw_skills` | After callers migrated |
+| `mcp/tool_discovery.py` | DEPRECATED — old custom MCP discovery | After `evidence_collector` migrated |
+| `mcp/tool_binding.py` | DEPRECATED | |
+| `mcp/tool_routing.py` | DEPRECATED | |
+| `mcp/tool_validation.py` | DEPRECATED | |
+| `mcp/base.py`, `client.py`, `server.py` | DEPRECATED | |
+| `mcp/parameter_validator.py` | DEPRECATED | |
+| `mcp/security.py` | DEPRECATED | |
+| `mcp/adapters/` | DEPRECATED (except as referenced by mcp.py router) | After mcp router is replaced |
+| `llm/nim_client.py` | ACTIVE INTEGRATION — wrapped by maiw_models | Keep until callers fully migrated |
+| `evidence/evidence_collector.py` | DEPRECATED — imports legacy mcp.tool_discovery | Remove after audit |
+| `evidence/evidence_integration.py` | DEPRECATED | |
+| `auth/` | ACTIVE — keep | |
+| `database.py` | ACTIVE — keep | |
+| `monitoring/` | ACTIVE — keep | |
+| `cache/` | ACTIVE — keep | |
+| `memory/` | ACTIVE — keep | |
+| `guardrails/` | ACTIVE — keep | |
+| `routing/semantic_router.py` | ACTIVE — used by chat router | |
+
+---
+
+## Compatibility Shim Removal Gate
+
+Shims are removed when **all** of the following are true:
+
+1. Zero production router imports the shim path
+2. Zero maintained test files import the shim path
+3. The new canonical path is exercised by CORE CI
+
+### Shim status at end of Phase 9B
+
+| Shim | Remaining callers | Status |
+|------|------------------|--------|
+| `src.api.services.model_gateway` | Legacy src agents (not on canonical path) | REMOVE — legacy agents are no longer on production call path after new app is active |
+| `src.api.skills.*` | Legacy src agents | REMOVE — same reason |
+
+---
+
+## MCP Legacy Status
+
+`src/api/services/mcp/` — 13 files (not counting `__init__.py`).
+
+Remaining callers after Phase 9B:
+- `src/api/routers/mcp.py` → **REPLACED** by `maiw_api.routers.mcp_status`
+- `src/api/graphs/mcp_*.py` → KEEP TEMPORARILY (LangGraph graphs used by chat router)
+- `src/api/services/evidence/evidence_collector.py` → DEPRECATE
+- `src/api/agents/*/mcp_*.py` → DEPRECATED stubs
+
+After Phase 9B, `src/api/services/mcp/` callers are isolated to legacy graphs and
+deprecated agent stubs. The new canonical `apps/api` app never imports from it.
+
+---
+
+## Forecasting Status
+
+`INTEGRATION-SPECIFIC`. `integrations/forecasting/` and
+`src/api/agents/forecasting/` remain as-is. The forecasting router is imported
+into the new app from `src.api.routers.advanced_forecasting` during Phase 9B.
+The forecasting integration does not use the `STATE → DECIDE → EXECUTE` pipeline.
+
+**FORECASTING LEGACY INTEGRATION BOUNDARY:** The forecasting router pulls
+`src.api.agents.forecasting.forecasting_agent` which imports
+`src.api.services.model_gateway` (the shim). This is tolerated in Phase 9B
+since forecasting remains on the legacy call path.
+
+---
+
+## Document Status
+
+`KEEP TEMPORARILY — DOCUMENT INTEGRATION`. The document pipeline depends on
+`asyncpg`, `pymilvus`, OCR libraries, and NeMo services. It is imported into the
+new app from `src.api.routers.document` and remains isolated behind the legacy
+call path. It is not part of Phase 9B scope.
+
+---
+
+## Docker / Deployment Impact
+
+- Dockerfile updated to: `pip install -e apps/api`
+- Entrypoint updated to: `uvicorn maiw_api.app:app`
+- PYTHONPATH includes `/app` (same as before)
+- All 7 canonical packages remain installed
+
+---
+
+## Test Strategy Update
+
+Phase 9B adds `tests/api/` as a new test tier. These tests:
+- Create the app without infrastructure
+- Verify route registration
+- Verify MAIWRuntime construction with mocks
+- Verify package dependency direction
+
+`tests/api/` is included in CORE CI if it is deterministic and
+infrastructure-free. See `TEST_STRATEGY.md` for the updated canonical command.

--- a/docs/architecture/PACKAGE_OWNERSHIP.md
+++ b/docs/architecture/PACKAGE_OWNERSHIP.md
@@ -111,12 +111,19 @@ Remove by Phase 9.
 
 | Module | Current path | Target | Status | Notes |
 |--------|-------------|--------|--------|-------|
-| `app.py` | `src/api/app.py` | `apps/api/maiw_api/app.py` | `MOVE NOW` | FastAPI application entry point |
-| All routers | `src/api/routers/` | `apps/api/maiw_api/routers/` | `MOVE NOW` | API-layer only |
-| `bootstrap.py` | *(does not exist)* | `apps/api/maiw_api/bootstrap.py` | `CREATE` | Composition root |
+| `app.py` | `src/api/app.py` | `apps/api/maiw_api/app.py` | `DONE (Phase 9B)` | Canonical FastAPI entrypoint: `uvicorn maiw_api.app:app` |
+| health router | `src/api/routers/health.py` | `apps/api/maiw_api/routers/health.py` | `DONE (Phase 9B)` | Adds MAIWRuntime status block to /health |
+| equipment router | `src/api/routers/equipment.py` | `apps/api/maiw_api/routers/equipment.py` | `DONE (Phase 9B)` | Write paths use canonical pipeline |
+| operations router | `src/api/routers/operations.py` | `apps/api/maiw_api/routers/operations.py` | `DONE (Phase 9B)` | SQL CRUD (bug-fixed); canonical agent via chat |
+| safety router | `src/api/routers/safety.py` | `apps/api/maiw_api/routers/safety.py` | `DONE (Phase 9B)` | SQL CRUD; static policies |
+| mcp router | `src/api/routers/mcp.py` | `apps/api/maiw_api/routers/mcp_status.py` | `REPLACED (Phase 9B)` | Legacy custom MCP replaced with canonical MCP v2 status endpoint |
+| `bootstrap.py` | (broken, Phase 8) | `apps/api/maiw_api/bootstrap.py` | `REWRITTEN (Phase 9B)` | MAIWRuntime composition root; correct full wiring |
+| `config.py` | (new) | `apps/api/maiw_api/config.py` | `DONE (Phase 9B)` | Application settings |
+| `dependencies.py` | (new) | `apps/api/maiw_api/dependencies.py` | `DONE (Phase 9B)` | FastAPI dependency helpers |
+| `lifespan.py` | (new) | `apps/api/maiw_api/lifespan.py` | `DONE (Phase 9B)` | Startup/shutdown |
 | Auth services | `src/api/services/auth/` | `apps/api/maiw_api/services/auth/` | `KEEP TEMPORARILY` | API-specific |
 | DB service | `src/api/services/database.py` | `apps/api/maiw_api/services/` | `KEEP TEMPORARILY` | Infrastructure |
-| Middleware | `src/api/middleware/` | `apps/api/maiw_api/middleware/` | `KEEP TEMPORARILY` | |
+| Middleware | `src/api/middleware/` | `apps/api/maiw_api/middleware/` | `KEEP TEMPORARILY` | Imported from src.api in Phase 9B |
 
 ---
 

--- a/docs/architecture/TEST_STRATEGY.md
+++ b/docs/architecture/TEST_STRATEGY.md
@@ -31,7 +31,7 @@ python -m pytest tests/unit/ tests/contract/ tests/mcp/ tests/api/ \
 **Phase 7 baseline:** 483 passed, 1 skipped, 0 failed (+97 new tests: Labor/Wave MCP, contract, state, executor, invariant)  
 **Phase 8 baseline:** 512 passed, 1 skipped, 0 failed (+29 new tests: package import smoke, forbidden-dependency guards, compatibility shim verification)  
 **Phase 9A baseline:** 528 passed, 1 skipped, 0 failed (+16 net: 20 new Phase 9A package import and invariant tests; −4 from deletion of dead MCP files whose callers were integration tests only)  
-**Phase 9B baseline:** 528 + tests/api/ passed (infrastructure-free app startup, router registration, architecture invariants)  
+**Phase 9B baseline:** 551 passed, 1 skipped, 0 failed (+23 new tests/api/ tests: app startup, router registration, equipment pipeline, architecture invariants)  
 All final phase reports MUST use this command. Any regression against the baseline is a blocker.
 
 > **Note:** `ci-cd.yml` previously ran only `tests/unit/` (327 tests). As of Phase 9A it was corrected to run `tests/unit/ tests/contract/ tests/mcp/` (528 tests). Phase 9B adds `tests/api/` to the canonical command.

--- a/docs/architecture/TEST_STRATEGY.md
+++ b/docs/architecture/TEST_STRATEGY.md
@@ -3,7 +3,7 @@
 ## Canonical CORE CI Command
 
 ```bash
-python -m pytest tests/unit/ tests/contract/ tests/mcp/ \
+python -m pytest tests/unit/ tests/contract/ tests/mcp/ tests/api/ \
   --ignore=tests/unit/test_all_agents.py \
   --ignore=tests/unit/test_basic.py \
   --ignore=tests/unit/test_nvidia_llm.py \
@@ -31,9 +31,10 @@ python -m pytest tests/unit/ tests/contract/ tests/mcp/ \
 **Phase 7 baseline:** 483 passed, 1 skipped, 0 failed (+97 new tests: Labor/Wave MCP, contract, state, executor, invariant)  
 **Phase 8 baseline:** 512 passed, 1 skipped, 0 failed (+29 new tests: package import smoke, forbidden-dependency guards, compatibility shim verification)  
 **Phase 9A baseline:** 528 passed, 1 skipped, 0 failed (+16 net: 20 new Phase 9A package import and invariant tests; −4 from deletion of dead MCP files whose callers were integration tests only)  
+**Phase 9B baseline:** 528 + tests/api/ passed (infrastructure-free app startup, router registration, architecture invariants)  
 All final phase reports MUST use this command. Any regression against the baseline is a blocker.
 
-> **Note:** `ci-cd.yml` previously ran only `tests/unit/` (327 tests). As of Phase 9A it has been corrected to run `tests/unit/ tests/contract/ tests/mcp/` (528 tests), matching this canonical definition.
+> **Note:** `ci-cd.yml` previously ran only `tests/unit/` (327 tests). As of Phase 9A it was corrected to run `tests/unit/ tests/contract/ tests/mcp/` (528 tests). Phase 9B adds `tests/api/` to the canonical command.
 
 All final phase reports MUST use this command. Any regression against the baseline is a blocker.
 
@@ -62,6 +63,7 @@ The 386 count is the canonical baseline from Phase 7 onward.
 tests/unit/          ← pure Python, no DB/API/GPU required
 tests/contract/      ← MCP capability contract tests (in-memory MockProvider)
 tests/mcp/           ← MCP protocol tests (in-memory FastMCP server)
+tests/api/           ← infrastructure-free API app/router tests (httpx ASGI transport)
 ```
 
 These tests run in < 10 seconds total. They require only the Python packages installed in the venv and no environment variables.

--- a/scripts/start_server.sh
+++ b/scripts/start_server.sh
@@ -33,9 +33,9 @@ PORT=${PORT:-8001}
 # Check if port is already in use
 if lsof -Pi :$PORT -sTCP:LISTEN -t >/dev/null 2>&1; then
     echo "⚠️  Port $PORT is already in use"
-    echo "   Stopping existing process..."
-    lsof -ti:$PORT | xargs kill -9 2>/dev/null || true
-    sleep 2
+    echo "   Another process (or Docker container) is already serving on this port."
+    echo "   Use 'lsof -ti:$PORT | xargs kill -9' to stop it manually if you want to restart."
+    exit 0
 fi
 
 echo "🚀 Starting Warehouse Operational Assistant API server..."

--- a/scripts/start_server.sh
+++ b/scripts/start_server.sh
@@ -47,5 +47,5 @@ echo "   Press Ctrl+C to stop the server"
 echo ""
 
 # Start the server
-python -m uvicorn src.api.app:app --reload --port $PORT --host 0.0.0.0
+python -m uvicorn maiw_api.app:app --reload --port $PORT --host 0.0.0.0
 

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""
+tests/api/conftest.py
+
+Stub native packages that are not installed in the CI test environment.
+These stubs must be in sys.modules before any src.* or maiw_api.* code is
+imported so that module-level import chains don't blow up at collection time.
+
+Packages stubbed here:
+  asyncpg      — PostgreSQL driver (requires C extension)
+  redis        — Redis client (requires a running server)
+  redis.asyncio — async Redis sub-package
+  pymilvus     — Milvus vector-DB client
+  bcrypt       — password hashing (C extension)
+
+Actual database / cache / vector-search calls are patched at the individual
+test or fixture level using unittest.mock.
+"""
+
+import sys
+from unittest.mock import MagicMock
+
+_STUBS = [
+    "asyncpg",
+    "redis",
+    "redis.asyncio",
+    "pymilvus",
+    "bcrypt",
+]
+
+for _mod in _STUBS:
+    if _mod not in sys.modules:
+        sys.modules[_mod] = MagicMock()

--- a/tests/api/test_app_startup.py
+++ b/tests/api/test_app_startup.py
@@ -71,30 +71,17 @@ def test_app():
 # ── Helpers ───────────────────────────────────────────────────────────────────
 
 
-def _collect_paths(node, _pfx: str = "") -> set:
+def _collect_paths(app) -> set:
     """
-    Recursively collect all fully-qualified route paths from a Starlette app
-    or router node.
+    Collect all registered route paths via FastAPI's OpenAPI schema.
 
-    Modern Starlette/FastAPI flattens ``include_router()`` calls so that every
-    item in ``app.routes`` is an ``APIRoute(path="/api/v1/equipment")``.
-    Older Starlette versions leave ``_IncludedRouter`` wrapper objects whose
-    own ``.path`` is the router prefix (e.g. ``"/api/v1"``) and whose
-    ``.routes`` children carry only the relative path (e.g. ``"/equipment"``).
-
-    This helper handles both layouts by walking the tree and accumulating
-    the prefix at each level before yielding a leaf path.
+    Walking ``app.routes`` directly is fragile: different Starlette versions
+    wrap ``include_router()`` results in different internal types
+    (``_IncludedRouter``, ``Mount``, etc.) with varying attribute layouts.
+    FastAPI always computes the OpenAPI schema correctly regardless of the
+    underlying Starlette version, so this approach is version-independent.
     """
-    node_path: str = getattr(node, "path", None) or ""
-    current: str = (_pfx.rstrip("/") + node_path) if _pfx else node_path
-
-    sub_routes = getattr(node, "routes", None)
-    if sub_routes is not None:
-        result: set = set()
-        for child in sub_routes:
-            result.update(_collect_paths(child, current))
-        return result
-    return {current} if current else set()
+    return set(app.openapi().get("paths", {}).keys())
 
 
 # ── Tests ─────────────────────────────────────────────────────────────────────

--- a/tests/api/test_app_startup.py
+++ b/tests/api/test_app_startup.py
@@ -68,6 +68,29 @@ def test_app():
         return app
 
 
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+
+def _collect_paths(app) -> set:
+    """
+    Collect all route paths from the app.
+
+    Newer Starlette flattens include_router() calls so every item in
+    app.routes is an APIRoute with a .path attribute.  Older versions
+    (and some edge cases) leave _IncludedRouter wrapper objects that
+    expose .routes but not .path.  This helper handles both.
+    """
+    paths: set = set()
+    for route in app.routes:
+        if hasattr(route, "path"):
+            paths.add(route.path)
+        if hasattr(route, "routes"):
+            for subroute in route.routes:
+                if hasattr(subroute, "path"):
+                    paths.add(subroute.path)
+    return paths
+
+
 # ── Tests ─────────────────────────────────────────────────────────────────────
 
 
@@ -79,7 +102,7 @@ def test_app_is_fastapi_instance(test_app):
 
 def test_canonical_routes_registered(test_app):
     """Canonical routers must register their paths on the app."""
-    paths = {route.path for route in test_app.routes}
+    paths = _collect_paths(test_app)
 
     expected = {
         "/api/v1/live",
@@ -103,14 +126,13 @@ def test_canonical_routes_registered(test_app):
 
 
 def test_root_endpoint(test_app):
-    paths = {route.path for route in test_app.routes}
+    paths = _collect_paths(test_app)
     assert "/" in paths
 
 
 def test_legacy_mcp_router_not_registered(test_app):
     """The retired legacy MCP router must NOT appear in the new app."""
-    paths = {route.path for route in test_app.routes}
-    # Legacy routes that must be absent
+    paths = _collect_paths(test_app)
     assert "/api/v1/mcp/plan" not in paths
     assert "/api/v1/mcp/bind" not in paths
     assert "/api/v1/mcp/route" not in paths

--- a/tests/api/test_app_startup.py
+++ b/tests/api/test_app_startup.py
@@ -71,24 +71,30 @@ def test_app():
 # ── Helpers ───────────────────────────────────────────────────────────────────
 
 
-def _collect_paths(app) -> set:
+def _collect_paths(node, _pfx: str = "") -> set:
     """
-    Collect all route paths from the app.
+    Recursively collect all fully-qualified route paths from a Starlette app
+    or router node.
 
-    Newer Starlette flattens include_router() calls so every item in
-    app.routes is an APIRoute with a .path attribute.  Older versions
-    (and some edge cases) leave _IncludedRouter wrapper objects that
-    expose .routes but not .path.  This helper handles both.
+    Modern Starlette/FastAPI flattens ``include_router()`` calls so that every
+    item in ``app.routes`` is an ``APIRoute(path="/api/v1/equipment")``.
+    Older Starlette versions leave ``_IncludedRouter`` wrapper objects whose
+    own ``.path`` is the router prefix (e.g. ``"/api/v1"``) and whose
+    ``.routes`` children carry only the relative path (e.g. ``"/equipment"``).
+
+    This helper handles both layouts by walking the tree and accumulating
+    the prefix at each level before yielding a leaf path.
     """
-    paths: set = set()
-    for route in app.routes:
-        if hasattr(route, "path"):
-            paths.add(route.path)
-        if hasattr(route, "routes"):
-            for subroute in route.routes:
-                if hasattr(subroute, "path"):
-                    paths.add(subroute.path)
-    return paths
+    node_path: str = getattr(node, "path", None) or ""
+    current: str = (_pfx.rstrip("/") + node_path) if _pfx else node_path
+
+    sub_routes = getattr(node, "routes", None)
+    if sub_routes is not None:
+        result: set = set()
+        for child in sub_routes:
+            result.update(_collect_paths(child, current))
+        return result
+    return {current} if current else set()
 
 
 # ── Tests ─────────────────────────────────────────────────────────────────────

--- a/tests/api/test_app_startup.py
+++ b/tests/api/test_app_startup.py
@@ -1,0 +1,151 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""
+tests/api/test_app_startup.py
+
+Infrastructure-free tests that verify the MAIW API app can be constructed
+and that its canonical routers are registered.  No database, Redis, or MCP
+server is required.
+
+Strategy:
+    1. Stub the lifespan so it doesn't try to connect to any external service.
+    2. Pre-populate ``app.state.runtime`` with a minimal MAIWRuntime mock.
+    3. Use httpx.AsyncClient (ASGI transport) — no real HTTP port opened.
+"""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+
+def _make_mock_runtime():
+    rt = MagicMock()
+    rt.equipment_agent = None
+    rt.operations_agent = None
+    rt.safety_agent = None
+    rt.mcp_client = None
+    rt.mcp_registry = None
+    rt.mcp_inventory_available = False
+    rt.mcp_equipment_available = False
+    rt.mcp_labor_available = False
+    rt.mcp_wave_available = False
+    return rt
+
+
+@asynccontextmanager
+async def _noop_lifespan(app: FastAPI):
+    app.state.runtime = _make_mock_runtime()
+    yield
+
+
+@pytest.fixture()
+def test_app():
+    """MAIW app with a no-op lifespan and mocked middleware deps."""
+    # Patch lifespan before importing app so the module-level object picks it up
+    with (
+        patch("maiw_api.app.lifespan", _noop_lifespan),
+        patch(
+            "src.api.services.security.rate_limiter.get_rate_limiter",
+            return_value=AsyncMock(check_rate_limit=AsyncMock()),
+        ),
+        patch(
+            "src.api.services.monitoring.metrics.record_request_metrics",
+        ),
+    ):
+        # Import here so patches are active
+        import importlib
+        import maiw_api.app as app_module
+
+        importlib.reload(app_module)
+        return app_module.app
+
+
+# ── Tests ─────────────────────────────────────────────────────────────────────
+
+
+def test_app_is_fastapi_instance(test_app):
+    from fastapi import FastAPI
+
+    assert isinstance(test_app, FastAPI)
+
+
+def test_canonical_routes_registered(test_app):
+    """Canonical routers must register their paths on the app."""
+    paths = {route.path for route in test_app.routes}
+
+    expected = {
+        "/api/v1/live",
+        "/api/v1/ready",
+        "/api/v1/health",
+        "/api/v1/health/simple",
+        "/api/v1/version",
+        "/api/v1/equipment",
+        "/api/v1/equipment/assign",
+        "/api/v1/equipment/release",
+        "/api/v1/equipment/maintenance",
+        "/api/v1/operations/tasks",
+        "/api/v1/operations/workforce",
+        "/api/v1/safety/incidents",
+        "/api/v1/safety/policies",
+        "/api/v1/mcp/status",
+        "/api/v1/mcp/capabilities",
+    }
+    missing = expected - paths
+    assert not missing, f"Missing routes: {missing}"
+
+
+def test_root_endpoint(test_app):
+    paths = {route.path for route in test_app.routes}
+    assert "/" in paths
+
+
+def test_legacy_mcp_router_not_registered(test_app):
+    """The retired legacy MCP router must NOT appear in the new app."""
+    paths = {route.path for route in test_app.routes}
+    # Legacy routes that must be absent
+    assert "/api/v1/mcp/plan" not in paths
+    assert "/api/v1/mcp/bind" not in paths
+    assert "/api/v1/mcp/route" not in paths
+
+
+def test_app_title_set(test_app):
+    assert "Warehouse" in test_app.title or "MAIW" in test_app.title
+
+
+@pytest.mark.asyncio
+async def test_health_live_without_infrastructure(test_app):
+    """GET /api/v1/live must return 200 without any external connections."""
+    import httpx
+    from httpx import ASGITransport
+
+    async with httpx.AsyncClient(
+        transport=ASGITransport(app=test_app),
+        base_url="http://test",
+    ) as client:
+        resp = await client.get("/api/v1/live")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "alive"
+
+
+@pytest.mark.asyncio
+async def test_mcp_status_without_server(test_app):
+    """GET /api/v1/mcp/status must return 200 even when no MCP server is configured."""
+    import httpx
+    from httpx import ASGITransport
+
+    async with httpx.AsyncClient(
+        transport=ASGITransport(app=test_app),
+        base_url="http://test",
+    ) as client:
+        resp = await client.get("/api/v1/mcp/status")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "domains" in body
+    assert "client_ready" in body

--- a/tests/api/test_app_startup.py
+++ b/tests/api/test_app_startup.py
@@ -47,7 +47,6 @@ async def _noop_lifespan(app: FastAPI):
 @pytest.fixture()
 def test_app():
     """MAIW app with a no-op lifespan and mocked middleware deps."""
-    # Patch lifespan before importing app so the module-level object picks it up
     with (
         patch("maiw_api.app.lifespan", _noop_lifespan),
         patch(
@@ -58,12 +57,15 @@ def test_app():
             "src.api.services.monitoring.metrics.record_request_metrics",
         ),
     ):
-        # Import here so patches are active
         import importlib
         import maiw_api.app as app_module
 
         importlib.reload(app_module)
-        return app_module.app
+        app = app_module.app
+        # ASGITransport does not run the ASGI lifespan events, so set state
+        # directly so that get_runtime(request) can find it.
+        app.state.runtime = _make_mock_runtime()
+        return app
 
 
 # ── Tests ─────────────────────────────────────────────────────────────────────
@@ -118,7 +120,7 @@ def test_app_title_set(test_app):
     assert "Warehouse" in test_app.title or "MAIW" in test_app.title
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_health_live_without_infrastructure(test_app):
     """GET /api/v1/live must return 200 without any external connections."""
     import httpx
@@ -134,7 +136,7 @@ async def test_health_live_without_infrastructure(test_app):
     assert body["status"] == "alive"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_mcp_status_without_server(test_app):
     """GET /api/v1/mcp/status must return 200 even when no MCP server is configured."""
     import httpx

--- a/tests/api/test_architecture.py
+++ b/tests/api/test_architecture.py
@@ -1,0 +1,148 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""
+tests/api/test_architecture.py
+
+Package dependency direction tests.
+
+Rule: canonical packages (maiw-*) must not import from the API layer
+(maiw_api or src.api).  The API layer may import from packages — not
+the other way around.
+
+These tests grep the source of each package and assert no forbidden
+import patterns exist.
+"""
+
+from __future__ import annotations
+
+import ast
+import os
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).parent.parent.parent
+
+# Paths to canonical packages
+CANONICAL_PACKAGES = [
+    REPO_ROOT / "packages" / "maiw-models" / "maiw_models",
+    REPO_ROOT / "packages" / "maiw-mcp" / "maiw_mcp",
+    REPO_ROOT / "packages" / "maiw-state" / "maiw_state",
+    REPO_ROOT / "packages" / "maiw-skills" / "maiw_skills",
+    REPO_ROOT / "packages" / "maiw-decision" / "maiw_decision",
+    REPO_ROOT / "packages" / "maiw-execution" / "maiw_execution",
+    REPO_ROOT / "packages" / "maiw-agents" / "maiw_agents",
+]
+
+# Import prefixes that canonical packages must never use
+FORBIDDEN_IMPORTS_FROM_PACKAGES = [
+    "maiw_api",
+    "src.api",
+    "apps.api",
+]
+
+
+def _python_files(directory: Path):
+    return directory.rglob("*.py")
+
+
+def _imports_in_file(path: Path) -> list[str]:
+    """Return all dotted module names imported in a Python file."""
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+    except SyntaxError:
+        return []
+    imports = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                imports.append(alias.name)
+        elif isinstance(node, ast.ImportFrom):
+            if node.module:
+                imports.append(node.module)
+    return imports
+
+
+@pytest.mark.parametrize("pkg_path", CANONICAL_PACKAGES, ids=lambda p: p.parent.name)
+def test_package_does_not_import_api_layer(pkg_path: Path):
+    """Canonical packages must not import from the API layer."""
+    if not pkg_path.exists():
+        pytest.skip(f"{pkg_path} not found")
+
+    violations: list[str] = []
+    for py_file in _python_files(pkg_path):
+        for imp in _imports_in_file(py_file):
+            for forbidden in FORBIDDEN_IMPORTS_FROM_PACKAGES:
+                if imp == forbidden or imp.startswith(forbidden + "."):
+                    violations.append(f"{py_file.relative_to(REPO_ROOT)}: import {imp}")
+
+    assert (
+        not violations
+    ), f"Dependency direction violation in {pkg_path.parent.name}:\n" + "\n".join(
+        violations
+    )
+
+
+def test_bootstrap_imports_from_packages_only():
+    """bootstrap.py must not import from src.api except for integration adapters."""
+    bootstrap = REPO_ROOT / "apps" / "api" / "maiw_api" / "bootstrap.py"
+    if not bootstrap.exists():
+        pytest.skip("bootstrap.py not found")
+
+    forbidden_in_bootstrap = [
+        "src.api.services.model_gateway",
+        "src.api.skills",
+        "src.api.agents.inventory.equipment_agent",
+        "src.api.agents.operations.operations_agent",
+        "src.api.agents.safety.safety_agent",
+        "src.api.services.mcp",
+    ]
+
+    imports = _imports_in_file(bootstrap)
+    violations = [
+        imp
+        for imp in imports
+        for forbidden in forbidden_in_bootstrap
+        if imp == forbidden or imp.startswith(forbidden + ".")
+    ]
+
+    assert (
+        not violations
+    ), "bootstrap.py imports from forbidden src.api paths:\n" + "\n".join(violations)
+
+
+def test_maiw_api_routers_do_not_import_src_agents():
+    """Canonical routers must not import from src.api.agents (use runtime instead)."""
+    routers_dir = REPO_ROOT / "apps" / "api" / "maiw_api" / "routers"
+    if not routers_dir.exists():
+        pytest.skip("maiw_api/routers not found")
+
+    violations = []
+    for py_file in routers_dir.rglob("*.py"):
+        for imp in _imports_in_file(py_file):
+            if imp.startswith("src.api.agents"):
+                violations.append(f"{py_file.name}: import {imp}")
+
+    assert (
+        not violations
+    ), "Canonical routers must not import from src.api.agents:\n" + "\n".join(
+        violations
+    )
+
+
+def test_maiw_api_package_exists():
+    pkg = REPO_ROOT / "apps" / "api" / "maiw_api"
+    assert pkg.is_dir(), "maiw_api package directory must exist"
+    assert (pkg / "__init__.py").exists(), "maiw_api/__init__.py must exist"
+    assert (pkg / "app.py").exists(), "maiw_api/app.py must exist"
+    assert (pkg / "bootstrap.py").exists(), "maiw_api/bootstrap.py must exist"
+
+
+def test_pyproject_lists_execution_and_agents():
+    """apps/api/pyproject.toml must declare maiw-execution and maiw-agents."""
+    pyproject = REPO_ROOT / "apps" / "api" / "pyproject.toml"
+    if not pyproject.exists():
+        pytest.skip("pyproject.toml not found")
+    content = pyproject.read_text()
+    assert "maiw-execution" in content, "pyproject.toml must declare maiw-execution"
+    assert "maiw-agents" in content, "pyproject.toml must declare maiw-agents"

--- a/tests/api/test_equipment_router.py
+++ b/tests/api/test_equipment_router.py
@@ -1,0 +1,231 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""
+tests/api/test_equipment_router.py
+
+Infrastructure-free unit tests for the canonical equipment router.
+Uses httpx ASGI transport — no real HTTP port opened.
+
+All DB and agent calls are patched at the transport level.
+"""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# ── App fixture (no external deps) ────────────────────────────────────────────
+
+
+def _make_runtime(*, with_agent: bool = True):
+    rt = MagicMock()
+    rt.mcp_client = None
+    rt.mcp_registry = None
+    rt.mcp_inventory_available = False
+    rt.mcp_equipment_available = bool(with_agent)
+    rt.mcp_labor_available = False
+    rt.mcp_wave_available = False
+
+    if with_agent:
+        agent = MagicMock()
+        agent.propose_equipment_assignment = AsyncMock(
+            return_value={
+                "status": "requires_human_approval",
+                "action": "warehouse.equipment.assign",
+                "proposal_id": "p-001",
+                "decision_id": "d-001",
+                "reason": "Requires human approval",
+                "executed": False,
+            }
+        )
+        agent.propose_equipment_release = AsyncMock(
+            return_value={
+                "status": "approved",
+                "action": "warehouse.equipment.release",
+                "proposal_id": "p-002",
+                "decision_id": "d-002",
+                "reason": "Auto-approved",
+                "executed": True,
+                "execution_id": "e-002",
+            }
+        )
+        agent.propose_schedule_maintenance = AsyncMock(
+            return_value={
+                "status": "requires_human_approval",
+                "action": "warehouse.equipment.schedule_maintenance",
+                "proposal_id": "p-003",
+                "decision_id": "d-003",
+                "reason": "Maintenance requires approval",
+                "executed": False,
+            }
+        )
+        asset_tools = MagicMock()
+        asset_tools.get_equipment_status = AsyncMock(
+            return_value={"asset_id": "AMR-001", "status": "idle"}
+        )
+        asset_tools.get_equipment_telemetry = AsyncMock(
+            return_value={"telemetry_data": []}
+        )
+        agent.asset_tools = asset_tools
+        agent.get_equipment_state_snapshot = AsyncMock(return_value=None)
+        rt.equipment_agent = agent
+    else:
+        rt.equipment_agent = None
+
+    rt.operations_agent = None
+    rt.safety_agent = None
+    return rt
+
+
+@asynccontextmanager
+async def _lifespan(app, *, with_agent: bool = True):
+    app.state.runtime = _make_runtime(with_agent=with_agent)
+    yield
+
+
+@pytest.fixture()
+def app_with_agent():
+    from contextlib import asynccontextmanager
+
+    @asynccontextmanager
+    async def ls(app):
+        async with _lifespan(app, with_agent=True):
+            yield
+
+    with (
+        patch("maiw_api.app.lifespan", ls),
+        patch(
+            "src.api.services.security.rate_limiter.get_rate_limiter",
+            return_value=AsyncMock(check_rate_limit=AsyncMock()),
+        ),
+        patch("src.api.services.monitoring.metrics.record_request_metrics"),
+        patch("src.retrieval.structured.SQLRetriever.initialize", AsyncMock()),
+        patch(
+            "src.retrieval.structured.SQLRetriever.execute_query",
+            AsyncMock(return_value=[]),
+        ),
+    ):
+        import importlib
+        import maiw_api.app as m
+
+        importlib.reload(m)
+        yield m.app
+
+
+@pytest.fixture()
+def app_no_agent():
+    @asynccontextmanager
+    async def ls(app):
+        async with _lifespan(app, with_agent=False):
+            yield
+
+    with (
+        patch("maiw_api.app.lifespan", ls),
+        patch(
+            "src.api.services.security.rate_limiter.get_rate_limiter",
+            return_value=AsyncMock(check_rate_limit=AsyncMock()),
+        ),
+        patch("src.api.services.monitoring.metrics.record_request_metrics"),
+        patch("src.retrieval.structured.SQLRetriever.initialize", AsyncMock()),
+        patch(
+            "src.retrieval.structured.SQLRetriever.execute_query",
+            AsyncMock(return_value=[]),
+        ),
+    ):
+        import importlib
+        import maiw_api.app as m
+
+        importlib.reload(m)
+        yield m.app
+
+
+# ── Tests ─────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_get_all_equipment_returns_list(app_with_agent):
+    import httpx
+    from httpx import ASGITransport
+
+    async with httpx.AsyncClient(
+        transport=ASGITransport(app=app_with_agent), base_url="http://test"
+    ) as client:
+        resp = await client.get("/api/v1/equipment")
+    assert resp.status_code == 200
+    assert isinstance(resp.json(), list)
+
+
+@pytest.mark.asyncio
+async def test_assign_equipment_returns_decision(app_with_agent):
+    import httpx
+    from httpx import ASGITransport
+
+    payload = {
+        "asset_id": "AMR-001",
+        "assignee": "worker-42",
+        "assignment_type": "task",
+        "task_id": "T-99",
+    }
+    async with httpx.AsyncClient(
+        transport=ASGITransport(app=app_with_agent), base_url="http://test"
+    ) as client:
+        resp = await client.post("/api/v1/equipment/assign", json=payload)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "requires_human_approval"
+    assert "proposal_id" in body
+    assert "decision_id" in body
+
+
+@pytest.mark.asyncio
+async def test_release_equipment_approved(app_with_agent):
+    import httpx
+    from httpx import ASGITransport
+
+    payload = {"asset_id": "AMR-001", "released_by": "worker-42"}
+    async with httpx.AsyncClient(
+        transport=ASGITransport(app=app_with_agent), base_url="http://test"
+    ) as client:
+        resp = await client.post("/api/v1/equipment/release", json=payload)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "approved"
+    assert body["executed"] is True
+
+
+@pytest.mark.asyncio
+async def test_write_endpoint_returns_503_without_agent(app_no_agent):
+    """Write endpoints must return 503 when equipment_agent is None."""
+    import httpx
+    from httpx import ASGITransport
+
+    payload = {"asset_id": "AMR-001", "assignee": "worker-1"}
+    async with httpx.AsyncClient(
+        transport=ASGITransport(app=app_no_agent), base_url="http://test"
+    ) as client:
+        resp = await client.post("/api/v1/equipment/assign", json=payload)
+    assert resp.status_code == 503
+
+
+@pytest.mark.asyncio
+async def test_schedule_maintenance_returns_decision(app_with_agent):
+    import httpx
+    from httpx import ASGITransport
+
+    payload = {
+        "asset_id": "AMR-001",
+        "maintenance_type": "preventive",
+        "description": "Quarterly check",
+        "scheduled_by": "ops-team",
+        "scheduled_for": "2026-09-01T09:00:00",
+    }
+    async with httpx.AsyncClient(
+        transport=ASGITransport(app=app_with_agent), base_url="http://test"
+    ) as client:
+        resp = await client.post("/api/v1/equipment/maintenance", json=payload)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "requires_human_approval"
+    assert body["executed"] is False

--- a/tests/api/test_equipment_router.py
+++ b/tests/api/test_equipment_router.py
@@ -87,8 +87,6 @@ async def _lifespan(app, *, with_agent: bool = True):
 
 @pytest.fixture()
 def app_with_agent():
-    from contextlib import asynccontextmanager
-
     @asynccontextmanager
     async def ls(app):
         async with _lifespan(app, with_agent=True):
@@ -111,6 +109,8 @@ def app_with_agent():
         import maiw_api.app as m
 
         importlib.reload(m)
+        # ASGITransport does not trigger ASGI lifespan events; set state directly.
+        m.app.state.runtime = _make_runtime(with_agent=True)
         yield m.app
 
 
@@ -138,13 +138,15 @@ def app_no_agent():
         import maiw_api.app as m
 
         importlib.reload(m)
+        # ASGITransport does not trigger ASGI lifespan events; set state directly.
+        m.app.state.runtime = _make_runtime(with_agent=False)
         yield m.app
 
 
 # ── Tests ─────────────────────────────────────────────────────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_all_equipment_returns_list(app_with_agent):
     import httpx
     from httpx import ASGITransport
@@ -157,7 +159,7 @@ async def test_get_all_equipment_returns_list(app_with_agent):
     assert isinstance(resp.json(), list)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_assign_equipment_returns_decision(app_with_agent):
     import httpx
     from httpx import ASGITransport
@@ -179,7 +181,7 @@ async def test_assign_equipment_returns_decision(app_with_agent):
     assert "decision_id" in body
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_release_equipment_approved(app_with_agent):
     import httpx
     from httpx import ASGITransport
@@ -195,7 +197,7 @@ async def test_release_equipment_approved(app_with_agent):
     assert body["executed"] is True
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_write_endpoint_returns_503_without_agent(app_no_agent):
     """Write endpoints must return 503 when equipment_agent is None."""
     import httpx
@@ -209,7 +211,7 @@ async def test_write_endpoint_returns_503_without_agent(app_no_agent):
     assert resp.status_code == 503
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_schedule_maintenance_returns_decision(app_with_agent):
     import httpx
     from httpx import ASGITransport


### PR DESCRIPTION
## Summary

- **Canonical FastAPI entrypoint** moved to \`apps/api/maiw_api/app.py\` (was \`src/api/app.py\`). New start command: \`uvicorn maiw_api.app:app --port 8001\`
- **MAIWRuntime** fully rewritten as the composition root (\`bootstrap.py\`): fixes broken Phase 8 syntax, wires CapabilityRegistry → MAIWMCPClient → Skills → StateProvider → Executors → Canonical Agents in the correct dependency order
- **Canonical routers** (health, equipment, operations, safety, MCP status) migrated to \`apps/api/maiw_api/routers/\`; legacy src/ routers (auth, chat, wms, iot, forecasting, etc.) imported as-is until Phase 10
- **Equipment write paths** now go through the canonical STATE → REASON → PROPOSE → DECIDE → EXECUTE pipeline via \`runtime.equipment_agent\`; write endpoints return 503 when agent is unavailable
- **Legacy MCP router** (\`src/api/routers/mcp.py\`, custom ToolDiscoveryService etc.) replaced by \`routers/mcp_status.py\` that exposes canonical MCP v2 capability registry status
- **Architecture tests** (\`tests/api/test_architecture.py\`) enforce that canonical packages never import from the API layer
- **Bug fixed**: operations.py PUT handler referenced undefined \`task_queries\` — fixed
- Docker and CI updated: install \`apps/api\`, \`tests/api/\` added to CORE CI

## Baseline

528 passed, 1 skipped, 0 failed (CORE CI: unit + contract + mcp) — preserved from Phase 9A.
11 new architecture/API tests in \`tests/api/\` pass.

## Test plan

- [ ] CORE CI passes: \`pytest tests/unit tests/contract tests/mcp tests/api/\`
- [ ] Docker build succeeds with updated \`Dockerfile.backend\`
- [ ] \`GET /api/v1/live\` → 200 \`{"status": "alive"}\`
- [ ] \`GET /api/v1/mcp/status\` → 200 with domain availability flags
- [ ] \`POST /api/v1/equipment/assign\` with MCP equipment server configured → canonical pipeline response
- [ ] \`POST /api/v1/equipment/assign\` without MCP server → 503