### PR TITLE
Feat/phase 15 copilot

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,15 +12,118 @@
 
 ## What MAIW Is
 
-MAIW is a multi-agent system that lets warehouse operators ask natural-language questions and issue
-structured commands against live warehouse data. It does not answer from static knowledge. Instead,
-each agent assembles real-time state, reasons over it with a Nemotron model, proposes a concrete
-action, passes the proposal through a local decision engine, and — if approved — executes it
-through an MCP v2 capability server that writes to the backend database.
+**MAIW — Multi-Agent Intelligent Warehouse — is an operational AI architecture for reasoning about, governing, and acting on dynamic warehouse systems.**
 
-The system is designed around a single non-negotiable invariant: **the LLM never touches a write
-path directly**. Every mutation is proposed, evaluated by a deterministic policy engine, and
-executed by a typed executor that enforces four guards before a write reaches MCP.
+MAIW is designed around a simple question:
+
+> **What does it take for AI to participate safely in running a warehouse — not simply answer questions about one?**
+
+Warehouse operations are continuously changing. Workers move between tasks, equipment fails, inventory changes, orders arrive, waves approach carrier cutoffs, and the state observed when reasoning begins may no longer be valid when an action is ready to execute.
+
+MAIW addresses this by separating intelligence from operational authority.
+
+The core lifecycle is:
+
+**Observe → Reason → Propose → Decide → Approve → Execute → Observe Outcome**
+
+### Observe
+
+MAIW assembles a canonical `WarehouseState` across inventory, labor, equipment, and wave operations.
+
+In Demo Mode, this state originates from a reproducible Warehouse World:
+
+```
+WarehouseWorldConfig → Canonical Operational Graph → WarehouseDataPack
+        → ScenarioOverlay → Runtime World → WarehouseState
+```
+
+The Operational Graph models entities, relationships, events, and time — for example:
+
+```
+Worker → Task → Wave → Order → CarrierCutoff
+```
+
+This gives agents a coherent operational context rather than a collection of disconnected synthetic records.
+
+### Reason
+
+Agents request intelligence through a centralized **ModelGateway**, which selects the appropriate NVIDIA Nemotron model according to reasoning requirements, risk, and routing policy. Agents express what level of reasoning a decision requires; ModelGateway chooses the physical model.
+
+Agents interact with warehouse domains through typed skills and vendor-neutral MCP capabilities.
+
+### Propose
+
+AI recommendations do not directly mutate warehouse systems.
+
+They are converted into typed `ActionProposal` objects that explicitly describe the requested operational action, target, risk, and trace identity. A recommendation is intelligence; an `ActionProposal` is a governed operational artifact.
+
+### Decide
+
+Every proposal passes through a deterministic **DecisionEngine** that evaluates operational policy, state validity, risk, and invariants.
+
+The language model is not the authority that decides whether a consequential warehouse action may execute.
+
+### Approve
+
+Where human authority is required, approval is explicit, expirable, bound to the proposal and decision, and single-use.
+
+### Execute
+
+Only a guarded **ActionExecutor** may cross the execution boundary and invoke a write-capable MCP capability against the configured operational provider.
+
+The system maintains a non-negotiable invariant:
+
+> **The LLM never touches a write path directly.**
+
+AI recommends and proposes. The DecisionEngine governs. Human authority approves where required. The ActionExecutor executes.
+
+MCP capabilities connect MAIW to operational providers such as simulation backends, WMS/WES systems, enterprise services, or other warehouse control interfaces.
+
+### Observe Outcome
+
+Execution success is not necessarily operational success.
+
+MAIW observes the warehouse after execution and measures whether the intended operational outcome actually occurred: Did backlog fall? Did wave risk improve? Did throughput recover? Did the warehouse move toward the intended objective?
+
+This closes the operational loop.
+
+### Reliability and Provenance
+
+MAIW treats distributed-systems uncertainty as a first-class concern.
+
+If a write may have succeeded but its acknowledgement is lost, MAIW does not blindly retry:
+
+```
+UNKNOWN → suppress automatic retry → reread authoritative state → reconcile
+```
+
+Reconciliation may result in `CONFIRMED_EXECUTED` / `CONFIRMED_NOT_EXECUTED` / `INDETERMINATE`.
+
+The architecture also includes execution identity, idempotency protection, request deadlines, circuit breakers, graceful degradation, approval-state management, and deterministic fault-injection evaluation.
+
+Every operational interaction is traceable through:
+
+```
+Evidence → Agent Interpretation → Skills → Recommendation → ActionProposal
+        → Decision → Approval → Execution → Outcome
+```
+
+MAIW exposes structured reasoning artifacts and provenance — not hidden model chain-of-thought — through the Agentic Reasoning Canvas, Decision Graph, **Why This Decision?**, and Developer Trace.
+
+The Operational Graph and Decision Graph serve distinct purposes:
+
+- **Operational Graph** — warehouse reality and operational context.
+- **Decision Graph** — MAIW reasoning, governance, execution, and provenance.
+
+### Copilot (Phase 15 — in development)
+
+MAIW's Copilot architecture is designed as the conversational interaction layer over the same governed lifecycle. Natural-language requests may ask for explanation, analysis, or governed action, but Copilot never bypasses DecisionEngine, human approval, or ActionExecutor.
+
+---
+
+The result is not simply a collection of warehouse agents.
+
+**MAIW is a governed operational intelligence architecture that connects AI reasoning to safe, observable, traceable, and measurable warehouse action.**
 
 ---
 
@@ -1282,6 +1385,7 @@ package-based, MCP v2 system.
 | **DataPack + ScenarioOverlay** (`maiw-world` Phase 14C–D) | ✅ Done | Immutable `WarehouseDataPack` on disk; `ScenarioOverlay`; `ScenarioWorld` with entity-reference validation |
 | **Runtime projection** (`maiw-world` Phase 14E) | ✅ Done | `WarehouseProjectionBuilder`; `DemoWarehouseWorld` rebuilt from immutable sources on reset; providers and agents unchanged |
 | **v2 developer notebook + setup workflow** | 🔲 Phase 14F | `clone → configure → generate → validate → launch` journey |
+| **Copilot — ASK path** (Phase 15B) | 🔄 In development | `CopilotService`, `POST /api/v1/copilot/turn`, 41 architecture + behavior tests; on `feat/phase-15-copilot` |
 
 ---
 
@@ -1305,7 +1409,7 @@ package-based, MCP v2 system.
 ## Contributing
 
 1. Fork the repository and create a feature branch.
-2. All changes must keep CORE CI green: current baseline 990 CORE CI tests passing (197 maiw-world + API, 388 reliability Batches 1–7, and the remaining unit/contract/mcp suite) + 94 frontend tests; zero new failures.
+2. All changes must keep CORE CI green: current baseline 990 CORE CI tests passing + 258 maiw-world and API tests + 500 frontend tests; zero new failures.
 3. New canonical code goes in `packages/`, never in `src.*` for business logic.
 4. No `src.*` imports in any `packages/` code — enforced by the test suite.
 5. Commit messages must follow [Conventional Commits](https://www.conventionalcommits.org/).

--- a/apps/api/maiw_api/app.py
+++ b/apps/api/maiw_api/app.py
@@ -43,6 +43,7 @@ from maiw_api.routers.safety import router as safety_router
 from maiw_api.routers.mcp_status import router as mcp_status_router
 from maiw_api.routers.runtime_status import router as runtime_status_router
 from maiw_api.routers.demo import router as demo_router
+from maiw_api.routers.copilot import router as copilot_router
 
 # ── Legacy routers (keep temporarily) ────────────────────────────────────────
 from src.api.routers.auth import router as auth_router
@@ -239,6 +240,7 @@ app.include_router(safety_router)
 app.include_router(mcp_status_router)
 app.include_router(runtime_status_router)
 app.include_router(demo_router)
+app.include_router(copilot_router)
 
 # Legacy (keep temporarily)
 app.include_router(auth_router)

--- a/apps/api/maiw_api/bootstrap.py
+++ b/apps/api/maiw_api/bootstrap.py
@@ -115,6 +115,9 @@ class MAIWRuntime:
     operations_agent: Any = None  # maiw_agents.operations.OperationsCoordinationAgent
     safety_agent: Any = None  # maiw_agents.safety.SafetyComplianceAgent
 
+    # Copilot service (Phase 15)
+    copilot_service: Any = None  # maiw_api.copilot.CopilotService
+
 
 async def get_runtime() -> MAIWRuntime:
     """
@@ -422,6 +425,34 @@ async def get_runtime() -> MAIWRuntime:
         logger.info("MAIW bootstrap: SafetyComplianceAgent ready")
     except Exception as exc:
         logger.warning("MAIW bootstrap: SafetyComplianceAgent unavailable — %s", exc)
+
+    # ── 12. CopilotService ────────────────────────────────────────────────────
+    try:
+        from maiw_api.copilot.service import CopilotService
+        from maiw_api.copilot.store import InMemoryCopilotStore
+
+        graph = None
+        try:
+            from maiw_api.demo.world_loader import load_canonical_graph
+            graph = load_canonical_graph()
+        except Exception as exc:
+            logger.warning("MAIW bootstrap: Copilot — canonical graph unavailable (%s). "
+                           "ASK turns will degrade on graph context.", exc)
+
+        event_bus = None
+        if runtime.demo_controller is not None:
+            event_bus = getattr(runtime.demo_controller, "event_bus", None)
+
+        runtime.copilot_service = CopilotService(
+            operations_agent=runtime.operations_agent,
+            state_provider=runtime.state_provider,
+            event_bus=event_bus,
+            graph=graph,
+            store=InMemoryCopilotStore(),
+        )
+        logger.info("MAIW bootstrap: CopilotService ready (graph=%s)", graph is not None)
+    except Exception as exc:
+        logger.warning("MAIW bootstrap: CopilotService unavailable — %s", exc)
 
     _runtime = runtime
     logger.info("MAIW bootstrap: runtime assembly complete")

--- a/apps/api/maiw_api/copilot/__init__.py
+++ b/apps/api/maiw_api/copilot/__init__.py
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""
+MAIW Copilot — Phase 15.
+
+Copilot is the human-interaction layer over MAIW's existing operational
+intelligence and governed decision architecture. It is not a warehouse agent
+and not an execution engine.
+
+Trust boundary: Copilot may request intelligence and propose governed actions.
+Copilot must never become an alternative approval or execution path.
+
+Exports
+-------
+CopilotService    — orchestrates ASK / ANALYZE / ACT turns
+CopilotIntent     — typed intent enum
+CopilotTurn       — per-turn state
+InMemoryCopilotStore — process-local conversation store
+"""
+
+from .models import CopilotIntent, CopilotTurn, CopilotConversation, CopilotAskResult
+from .store import InMemoryCopilotStore
+from .service import CopilotService
+
+__all__ = [
+    "CopilotIntent",
+    "CopilotTurn",
+    "CopilotConversation",
+    "CopilotAskResult",
+    "InMemoryCopilotStore",
+    "CopilotService",
+]

--- a/apps/api/maiw_api/copilot/context.py
+++ b/apps/api/maiw_api/copilot/context.py
@@ -1,0 +1,170 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""
+OperationalContextResolver — bounded graph neighborhood for a Copilot turn.
+
+Deterministic graph BFS (no vector retrieval). Bounded by max_depth and
+max_entities to prevent passing the full 51k-entity DataPack to Nemotron.
+
+Phase 15B: depth=2, max_entities=50.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any
+
+from .models import ContextNeighborhood
+
+logger = logging.getLogger(__name__)
+
+_MAX_DEPTH = 2
+_MAX_ENTITIES = 50
+
+# Patterns that indicate an operator is asking about a specific wave number.
+_WAVE_NUMBER_RE = re.compile(r"\bwave\s*(\d+)\b", re.IGNORECASE)
+
+
+def _extract_wave_number(question: str) -> int | None:
+    m = _WAVE_NUMBER_RE.search(question)
+    return int(m.group(1)) if m else None
+
+
+def _entity_label(entity: Any) -> str:
+    """Best-effort human label from a WarehouseEntity."""
+    for attr in ("wave_number", "worker_id", "asset_id", "sku", "zone_id",
+                 "location_id", "dock_door_id", "order_id", "task_id",
+                 "shift_id", "carrier_id", "entity_id"):
+        val = getattr(entity, attr, None)
+        if val is not None:
+            return str(val)
+    return getattr(entity, "entity_id", "unknown")
+
+
+def _relationship_label(rel_type: Any) -> str:
+    name = str(rel_type)
+    return name.split(".")[-1].replace("_", " ").title()
+
+
+def resolve(
+    question: str,
+    warehouse_id: str,
+    graph: Any | None,
+) -> ContextNeighborhood:
+    """
+    Resolve a bounded Operational Graph neighborhood for the operator question.
+
+    Parameters
+    ----------
+    question:
+        Raw operator message.
+    warehouse_id:
+        Warehouse to scope entity lookup.
+    graph:
+        CanonicalWarehouseGraph instance, or None when DataPack is unavailable.
+
+    Returns
+    -------
+    ContextNeighborhood
+        Always returns a value — never raises. Sets graph_available=False
+        when graph is None or lookup fails.
+    """
+    if graph is None:
+        return ContextNeighborhood(
+            focus_entity_id=None,
+            focus_entity_label=None,
+            entity_ids=[],
+            relationship_summary={},
+            max_depth=_MAX_DEPTH,
+            graph_available=False,
+        )
+
+    try:
+        return _resolve_with_graph(question, graph)
+    except Exception as exc:
+        logger.warning("OperationalContextResolver: graph lookup failed — %s", exc)
+        return ContextNeighborhood(
+            focus_entity_id=None,
+            focus_entity_label=None,
+            entity_ids=[],
+            relationship_summary={},
+            max_depth=_MAX_DEPTH,
+            graph_available=False,
+        )
+
+
+def _resolve_with_graph(question: str, graph: Any) -> ContextNeighborhood:
+    from maiw_world.entities import EntityType
+
+    focus_entity = None
+    focus_label = None
+
+    # Try to find a specific wave entity
+    wave_num = _extract_wave_number(question)
+    if wave_num is not None:
+        waves = graph.entities_by_type(EntityType.WAVE)
+        for w in waves:
+            if getattr(w, "wave_number", None) == wave_num:
+                focus_entity = w
+                focus_label = f"Wave {wave_num}"
+                break
+        if focus_entity is None and waves:
+            # Fallback: use the first wave (demo scenario always has waves)
+            focus_entity = waves[0]
+            focus_label = f"Wave {getattr(focus_entity, 'wave_number', '?')}"
+
+    # Fallback: no specific entity — use first at-risk wave if identifiable
+    if focus_entity is None:
+        waves = graph.entities_by_type(EntityType.WAVE)
+        if waves:
+            focus_entity = waves[0]
+            focus_label = f"Wave {getattr(focus_entity, 'wave_number', '?')}"
+
+    if focus_entity is None:
+        return ContextNeighborhood(
+            focus_entity_id=None,
+            focus_entity_label=None,
+            entity_ids=[],
+            relationship_summary={},
+            max_depth=_MAX_DEPTH,
+            graph_available=True,
+        )
+
+    focus_id = focus_entity.entity_id
+
+    # BFS up to max_depth hops in both directions
+    neighbors = graph.neighbors(
+        focus_id,
+        direction="both",
+        depth=_MAX_DEPTH,
+    )
+
+    # Cap total entities
+    neighbors = neighbors[:_MAX_ENTITIES]
+    entity_ids = [n.entity_id for n in neighbors]
+
+    # Build relationship summary grouped by entity type
+    rel_summary: dict[str, list[str]] = {}
+    edges = (
+        graph.outgoing_edges(focus_id) + graph.incoming_edges(focus_id)
+    )
+    for edge in edges:
+        other_id = edge.target_id if edge.source_id == focus_id else edge.source_id
+        other = graph.get_entity(other_id)
+        if other is None:
+            continue
+        group = other.entity_type.value.replace("_", " ").title() + "s"
+        label = _entity_label(other)
+        rel_summary.setdefault(group, [])
+        if label not in rel_summary[group]:
+            rel_summary[group].append(label)
+
+    return ContextNeighborhood(
+        focus_entity_id=focus_id,
+        focus_entity_label=focus_label,
+        entity_ids=entity_ids,
+        relationship_summary=rel_summary,
+        max_depth=_MAX_DEPTH,
+        graph_available=True,
+    )

--- a/apps/api/maiw_api/copilot/models.py
+++ b/apps/api/maiw_api/copilot/models.py
@@ -1,0 +1,169 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""
+Phase 15 Copilot typed contracts.
+
+Identity model
+--------------
+conversation_id  One operator Copilot session (drawer open → close / reset)
+turn_id          One operator message + one Copilot response
+trace_id         One MAIW reasoning trace (threaded to ModelGateway + proposals)
+
+These are never the same value. A three-turn conversation has one
+conversation_id and three (turn_id, trace_id) pairs.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+# ── Intent ────────────────────────────────────────────────────────────────────
+
+class CopilotIntent(str, Enum):
+    ASK     = "ask"      # read-only explanation — no proposal, no execution
+    ANALYZE = "analyze"  # assessment + recommendations — no mutation
+    ACT     = "act"      # ActionProposal → DecisionEngine → governed lifecycle
+
+
+# ── Structured evidence ───────────────────────────────────────────────────────
+
+@dataclass(frozen=True)
+class EvidenceFact:
+    label: str
+    value: str
+    severity: str | None = None  # "CRITICAL" | "HIGH" | "MEDIUM" | "LOW" | None
+
+
+@dataclass(frozen=True)
+class ContextNeighborhood:
+    """Bounded Operational Graph neighborhood resolved for the turn."""
+    focus_entity_id: str | None
+    focus_entity_label: str | None
+    entity_ids: list[str]
+    relationship_summary: dict[str, list[str]]  # e.g. {"Tasks": [...], "Workers": [...]}
+    max_depth: int
+    graph_available: bool
+
+
+# ── ASK result ────────────────────────────────────────────────────────────────
+
+@dataclass
+class CopilotAskResult:
+    """
+    Structured result of a Copilot ASK turn.
+
+    MUST contain zero ActionProposals, zero DecisionEngine evaluations,
+    zero writes. These are enforced by architecture invariant tests.
+    """
+    answer: str
+    evidence: list[EvidenceFact]
+    neighborhood: ContextNeighborhood
+    agent: str
+    skills_used: list[str]
+    model_id: str
+    reasoning_level: str
+    routing_rule: str
+    routing_reason: str
+    trace_id: str
+    snapshot_id: str
+    warehouse_id: str
+    latency_ms: float
+    degraded: bool = False
+    degradation_reason: str | None = None
+
+
+# ── Turn / Conversation store models ─────────────────────────────────────────
+
+@dataclass
+class CopilotTurn:
+    """
+    One operator message + one Copilot response.
+
+    Do NOT store chain_of_thought, scratchpad, hidden_reasoning,
+    reasoning_tokens — any field whose name suggests hidden model state.
+    """
+    turn_id: str
+    conversation_id: str
+    user_message: str
+    intent: CopilotIntent
+    created_at: datetime
+    trace_id: str
+    response_summary: str
+    artifact_refs: dict[str, str | None] = field(default_factory=dict)
+    # artifact_refs keys: proposal_id, decision_id, approval_id, execution_id
+    parent_turn_id: str | None = None
+    related_trace_ids: list[str] = field(default_factory=list)
+
+
+@dataclass
+class CopilotConversation:
+    """
+    One operator Copilot session.
+
+    Process-local: state is lost on API restart. This limitation is
+    documented in every CopilotTurnResponse.
+    """
+    conversation_id: str
+    warehouse_id: str
+    scenario_name: str
+    turns: list[CopilotTurn] = field(default_factory=list)
+    last_recommendations: list[Any] = field(default_factory=list)
+    related_trace_ids: list[str] = field(default_factory=list)
+    created_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+
+    def add_turn(self, turn: CopilotTurn) -> None:
+        self.turns.append(turn)
+        if turn.trace_id not in self.related_trace_ids:
+            self.related_trace_ids.append(turn.trace_id)
+
+    @property
+    def last_turn(self) -> CopilotTurn | None:
+        return self.turns[-1] if self.turns else None
+
+
+# ── API request / response shapes (Pydantic for FastAPI) ─────────────────────
+
+class CopilotTurnRequest(BaseModel):
+    conversation_id: str | None = Field(
+        default=None,
+        description="Existing conversation ID; omit to start a new conversation.",
+    )
+    message: str = Field(..., min_length=1, max_length=2000)
+    warehouse_id: str = Field(default="DC-47")
+    scenario_name: str = Field(default="")
+
+
+class CopilotTurnResponse(BaseModel):
+    conversation_id: str
+    turn_id: str
+    trace_id: str
+    intent: str
+    status: str  # "complete" | "degraded" | "error"
+
+    # ASK fields (present when intent=ask)
+    answer: str | None = None
+    evidence: list[dict] | None = None
+    neighborhood: dict | None = None
+    agent: str | None = None
+    skills_used: list[str] | None = None
+    model_id: str | None = None
+    reasoning_level: str | None = None
+    routing_rule: str | None = None
+    routing_reason: str | None = None
+    latency_ms: float | None = None
+    degraded: bool = False
+    degradation_reason: str | None = None
+
+    # Future: ANALYZE and ACT fields populated in 15C / 15D
+    related_artifacts: dict = Field(default_factory=dict)
+
+    # Explicitly NOT present: proposal, decision, approval, execution shortcuts
+    # See PHASE_15_COPILOT_ARCHITECTURE.md — trust boundary
+
+    store_note: str = "Conversation state is process-local and will not survive API restart."

--- a/apps/api/maiw_api/copilot/service.py
+++ b/apps/api/maiw_api/copilot/service.py
@@ -1,0 +1,398 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""
+CopilotService — Phase 15B: ASK path only.
+
+Trust boundary enforced by explicit import restrictions:
+    - MUST NOT import ActionExecutor
+    - MUST NOT call ApprovalStore.approve
+    - MUST NOT call DecisionEngine.evaluate
+    - MUST NOT create ActionProposal
+
+These are validated by architecture invariant tests in test_copilot_ask.py.
+
+Degradation policy
+------------------
+If WarehouseState cannot be assembled (provider unavailable, state provider
+None, or exception), ASK returns a structured degraded response rather than
+falling back to any simulated/invented operational data.
+
+If individual domains are unavailable, each missing domain is noted in
+degradation_reason; available domains still inform the answer.
+
+The agent's _simulate_workforce_data() fallback is suppressed by the
+CopilotService: if we cannot inject real state, we degrade explicitly.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from datetime import datetime, timezone
+from typing import Any
+
+try:
+    from maiw_state.warehouse import WarehouseStateSnapshot
+    from maiw_state import StateRequirements as _StateRequirements
+except ImportError:
+    WarehouseStateSnapshot = None  # type: ignore[assignment,misc]
+    _StateRequirements = None  # type: ignore[assignment]
+
+from . import context as context_resolver
+from .models import (
+    CopilotAskResult,
+    CopilotIntent,
+    CopilotTurn,
+    EvidenceFact,
+)
+from .store import InMemoryCopilotStore
+
+logger = logging.getLogger(__name__)
+
+
+class CopilotService:
+    """
+    Orchestrates Copilot ASK turns.
+
+    Phase 15B scope: ASK only. ANALYZE and ACT will be added in 15C/15D.
+
+    This class MUST NOT:
+    - import or call ActionExecutor
+    - import or call ApprovalStore.approve
+    - import or call DecisionEngine.evaluate
+    - construct or return ActionProposal
+
+    Dependencies are injected at construction time (same pattern as bootstrap.py).
+    """
+
+    def __init__(
+        self,
+        *,
+        operations_agent: Any,
+        state_provider: Any,
+        event_bus: Any | None = None,
+        graph: Any | None = None,
+        store: InMemoryCopilotStore | None = None,
+    ) -> None:
+        self._agent = operations_agent
+        self._state_provider = state_provider
+        self._event_bus = event_bus
+        self._graph = graph
+        self._store = store or InMemoryCopilotStore()
+
+    @property
+    def store(self) -> InMemoryCopilotStore:
+        return self._store
+
+    async def ask(
+        self,
+        *,
+        message: str,
+        conversation_id: str | None,
+        warehouse_id: str,
+        scenario_name: str = "",
+    ) -> tuple[CopilotAskResult, CopilotTurn]:
+        """
+        Process an ASK turn end-to-end.
+
+        Returns (CopilotAskResult, CopilotTurn). The caller persists the turn
+        via store.add_turn() after this method returns.
+
+        Zero ActionProposals, zero DecisionEngine evaluations, zero writes.
+        """
+        trace_id = str(uuid.uuid4())
+        turn_id = str(uuid.uuid4())
+
+        conv = self._store.get_or_create(
+            conversation_id, warehouse_id, scenario_name
+        )
+
+        await self._publish("COPILOT_TURN_STARTED", f"Copilot ASK — turn {turn_id[:8]}", trace_id=trace_id)
+
+        # ── Resolve intent ────────────────────────────────────────────────────
+        intent = CopilotIntent.ASK
+        await self._publish("COPILOT_INTENT_RESOLVED", "intent=ASK", trace_id=trace_id)
+
+        # ── Assemble WarehouseState ───────────────────────────────────────────
+        state, state_degraded, state_degradation_reason = await self._get_state(
+            warehouse_id=warehouse_id,
+            trace_id=trace_id,
+        )
+
+        # ── Resolve Operational Graph neighborhood ────────────────────────────
+        neighborhood = context_resolver.resolve(
+            question=message,
+            warehouse_id=warehouse_id,
+            graph=self._graph,
+        )
+
+        await self._publish(
+            "COPILOT_CONTEXT_RESOLVED",
+            f"focus={neighborhood.focus_entity_label or 'none'} "
+            f"entities={len(neighborhood.entity_ids)} "
+            f"graph_available={neighborhood.graph_available}",
+            trace_id=trace_id,
+        )
+
+        # ── Degrade if state is entirely unavailable ──────────────────────────
+        if state is None:
+            result = CopilotAskResult(
+                answer=(
+                    "I cannot answer this question right now. "
+                    + (state_degradation_reason or "Warehouse state is unavailable.")
+                ),
+                evidence=[],
+                neighborhood=neighborhood,
+                agent="OperationsCoordinationAgent",
+                skills_used=[],
+                model_id="none",
+                reasoning_level="MEDIUM",
+                routing_rule="none",
+                routing_reason="State unavailable — skipped",
+                trace_id=trace_id,
+                snapshot_id="none",
+                warehouse_id=warehouse_id,
+                latency_ms=0.0,
+                degraded=True,
+                degradation_reason=state_degradation_reason,
+            )
+            turn = self._make_turn(
+                turn_id=turn_id,
+                conv_id=conv.conversation_id,
+                message=message,
+                intent=intent,
+                trace_id=trace_id,
+                result=result,
+            )
+            self._store.add_turn(turn)
+            await self._publish("COPILOT_TURN_COMPLETE", "degraded=true", trace_id=trace_id)
+            return result, turn
+
+        # ── Seal snapshot and call agent ──────────────────────────────────────
+        try:
+            from maiw_models import ReasoningLevel, RiskLevel
+
+            snapshot = WarehouseStateSnapshot.seal(state)
+
+            assessment = await self._agent.analyze_disruption(
+                snapshot=snapshot,
+                scenario_context=message,
+                trace_id=trace_id,
+                reasoning_level=ReasoningLevel.MEDIUM,
+                risk_level=RiskLevel.LOW,
+            )
+
+        except Exception as exc:
+            logger.error("CopilotService.ask: agent call failed — %s", exc)
+            result = CopilotAskResult(
+                answer="I encountered an error while analyzing the warehouse state.",
+                evidence=[],
+                neighborhood=neighborhood,
+                agent="OperationsCoordinationAgent",
+                skills_used=[],
+                model_id="none",
+                reasoning_level="MEDIUM",
+                routing_rule="none",
+                routing_reason=f"Agent error: {exc}",
+                trace_id=trace_id,
+                snapshot_id="none",
+                warehouse_id=warehouse_id,
+                latency_ms=0.0,
+                degraded=True,
+                degradation_reason=str(exc),
+            )
+            turn = self._make_turn(
+                turn_id=turn_id,
+                conv_id=conv.conversation_id,
+                message=message,
+                intent=intent,
+                trace_id=trace_id,
+                result=result,
+            )
+            self._store.add_turn(turn)
+            await self._publish("COPILOT_TURN_COMPLETE", "degraded=true error", trace_id=trace_id)
+            return result, turn
+
+        # ── Build structured evidence from assessment facts ───────────────────
+        evidence = _facts_to_evidence(assessment.facts_observed, assessment.severity)
+
+        # Add explicit note if domains were degraded
+        full_degradation = state_degradation_reason
+        if neighborhood.graph_available is False:
+            note = "Operational Graph unavailable — neighborhood context not shown."
+            full_degradation = (
+                f"{full_degradation}; {note}" if full_degradation else note
+            )
+
+        result = CopilotAskResult(
+            answer=assessment.summary,
+            evidence=evidence,
+            neighborhood=neighborhood,
+            agent="OperationsCoordinationAgent",
+            skills_used=assessment.skills_consulted,
+            model_id=assessment.model_id,
+            reasoning_level="MEDIUM",
+            routing_rule=assessment.routing_rule,
+            routing_reason=assessment.routing_reason,
+            trace_id=trace_id,
+            snapshot_id=assessment.snapshot_id,
+            warehouse_id=assessment.warehouse_id,
+            latency_ms=assessment.latency_ms,
+            degraded=bool(full_degradation),
+            degradation_reason=full_degradation or None,
+        )
+
+        turn = self._make_turn(
+            turn_id=turn_id,
+            conv_id=conv.conversation_id,
+            message=message,
+            intent=intent,
+            trace_id=trace_id,
+            result=result,
+        )
+        self._store.add_turn(turn)
+        await self._publish("COPILOT_TURN_COMPLETE", f"model={result.model_id}", trace_id=trace_id)
+        return result, turn
+
+    # ── Private helpers ───────────────────────────────────────────────────────
+
+    async def _get_state(
+        self,
+        warehouse_id: str,
+        trace_id: str,
+    ) -> tuple[Any | None, bool, str | None]:
+        """
+        Assemble WarehouseState. Returns (state, degraded, degradation_reason).
+
+        Never falls back to simulated data. If provider is unavailable or
+        call fails, returns (None, True, reason).
+        """
+        if self._state_provider is None:
+            return None, True, "WarehouseStateProvider is unavailable in this environment."
+
+        try:
+            requirements_cls = _StateRequirements
+            if requirements_cls is None:
+                from maiw_state import StateRequirements as requirements_cls  # type: ignore[no-redef]
+
+            state = await self._state_provider.get_state(
+                warehouse_id,
+                requirements_cls(equipment=True, labor=True, waves=True),
+                trace_id=trace_id,
+            )
+
+            # Note any unavailable domains but still return partial state
+            missing = []
+            if state.equipment is None:
+                missing.append("equipment")
+            if state.labor is None:
+                missing.append("labor")
+            if state.waves is None:
+                missing.append("waves")
+
+            if missing:
+                reason = (
+                    f"{', '.join(d.title() for d in missing)} state unavailable — "
+                    f"answer may be incomplete for those domains."
+                )
+                return state, True, reason
+
+            return state, False, None
+
+        except Exception as exc:
+            logger.warning("CopilotService._get_state failed — %s", exc)
+            return None, True, f"Warehouse state could not be assembled: {exc}"
+
+    async def _publish(self, category: str, message: str, *, trace_id: str) -> None:
+        if self._event_bus is None:
+            return
+        try:
+            from maiw_api.demo.events import ScenarioEvent
+
+            event = ScenarioEvent(
+                category=category,
+                message=message,
+                detail=f'{{"trace_id": "{trace_id}"}}',
+            )
+            await self._event_bus.publish(event)
+        except Exception as exc:
+            logger.debug("CopilotService._publish failed — %s", exc)
+
+    def _make_turn(
+        self,
+        *,
+        turn_id: str,
+        conv_id: str,
+        message: str,
+        intent: CopilotIntent,
+        trace_id: str,
+        result: CopilotAskResult,
+    ) -> CopilotTurn:
+        return CopilotTurn(
+            turn_id=turn_id,
+            conversation_id=conv_id,
+            user_message=message,
+            intent=intent,
+            created_at=datetime.now(timezone.utc),
+            trace_id=trace_id,
+            response_summary=result.answer[:200],
+            artifact_refs={},
+        )
+
+
+# ── Evidence extraction ───────────────────────────────────────────────────────
+
+_SEVERITY_KEYWORDS = {
+    "CRITICAL": "CRITICAL",
+    "critical": "CRITICAL",
+    "HIGH": "HIGH",
+    "high": "HIGH",
+    "at-risk": "HIGH",
+    "at_risk": "HIGH",
+    "OFFLINE": "HIGH",
+    "MAINTENANCE": "MEDIUM",
+    "maintenance": "MEDIUM",
+    "MEDIUM": "MEDIUM",
+    "medium": "MEDIUM",
+}
+
+
+def _facts_to_evidence(facts: list[str], assessment_severity: str) -> list[EvidenceFact]:
+    """
+    Convert OperationalAssessment.facts_observed into structured EvidenceFacts.
+
+    The facts are already structured strings produced by analyze_disruption;
+    we parse them into label/value/severity triples for the UI.
+    """
+    evidence: list[EvidenceFact] = []
+
+    for fact in facts:
+        # Detect severity from keywords in the fact text
+        severity = None
+        for kw, sev in _SEVERITY_KEYWORDS.items():
+            if kw in fact:
+                severity = sev
+                break
+
+        # UNASSIGNED PENDING TASKS is always HIGH — check before partition
+        if fact.startswith("UNASSIGNED"):
+            evidence.append(EvidenceFact(
+                label="Unassigned pending tasks",
+                value=fact.partition(": ")[2] or fact,
+                severity="HIGH",
+            ))
+        elif ": " in fact:
+            label, _, value = fact.partition(": ")
+            evidence.append(EvidenceFact(
+                label=label.strip(),
+                value=value.strip(),
+                severity=severity,
+            ))
+        else:
+            evidence.append(EvidenceFact(
+                label="Observation",
+                value=fact,
+                severity=severity,
+            ))
+
+    return evidence

--- a/apps/api/maiw_api/copilot/store.py
+++ b/apps/api/maiw_api/copilot/store.py
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""
+InMemoryCopilotStore — process-local conversation state.
+
+Scope mirrors InMemoryApprovalStore: single process, no persistence.
+Callers receive this limitation via CopilotTurnResponse.store_note.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+
+from .models import CopilotConversation, CopilotTurn
+
+
+class InMemoryCopilotStore:
+    def __init__(self) -> None:
+        self._conversations: dict[str, CopilotConversation] = {}
+
+    def create_conversation(
+        self,
+        warehouse_id: str,
+        scenario_name: str,
+    ) -> CopilotConversation:
+        conv = CopilotConversation(
+            conversation_id=str(uuid.uuid4()),
+            warehouse_id=warehouse_id,
+            scenario_name=scenario_name,
+        )
+        self._conversations[conv.conversation_id] = conv
+        return conv
+
+    def get_conversation(self, conversation_id: str) -> CopilotConversation | None:
+        return self._conversations.get(conversation_id)
+
+    def get_or_create(
+        self,
+        conversation_id: str | None,
+        warehouse_id: str,
+        scenario_name: str,
+    ) -> CopilotConversation:
+        if conversation_id and conversation_id in self._conversations:
+            return self._conversations[conversation_id]
+        conv = self.create_conversation(warehouse_id, scenario_name)
+        return conv
+
+    def add_turn(self, turn: CopilotTurn) -> None:
+        conv = self._conversations.get(turn.conversation_id)
+        if conv is not None:
+            conv.add_turn(turn)
+
+    def reset(self) -> None:
+        self._conversations.clear()

--- a/apps/api/maiw_api/demo/events.py
+++ b/apps/api/maiw_api/demo/events.py
@@ -56,6 +56,11 @@ EventCategory = Literal[
     "CONFIRMED_EXECUTED",  # Reconciliation confirmed: mutation occurred
     "CONFIRMED_NOT_EXECUTED",  # Reconciliation confirmed: mutation did not occur
     "INDETERMINATE",  # Reconciliation cannot resolve; manual intervention needed
+    # Copilot conversational turn events (Phase 15)
+    "COPILOT_TURN_STARTED",     # Operator message received; turn processing begins
+    "COPILOT_INTENT_RESOLVED",  # ASK / ANALYZE / ACT intent determined
+    "COPILOT_CONTEXT_RESOLVED", # WarehouseState + graph neighborhood assembled
+    "COPILOT_TURN_COMPLETE",    # Copilot response ready
 ]
 
 

--- a/apps/api/maiw_api/routers/copilot.py
+++ b/apps/api/maiw_api/routers/copilot.py
@@ -1,0 +1,98 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""
+Copilot API router — Phase 15B (ASK only).
+
+Endpoint
+--------
+POST /api/v1/copilot/turn
+
+Explicitly absent (trust boundary):
+    /copilot/approve  — MUST NOT exist
+    /copilot/execute  — MUST NOT exist
+    /copilot/force-action — MUST NOT exist
+
+These paths are validated by architecture invariant tests.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, HTTPException, Request
+
+from maiw_api.copilot.models import (
+    CopilotTurnRequest,
+    CopilotTurnResponse,
+)
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/v1/copilot", tags=["copilot"])
+
+
+def _get_copilot_service(request: Request):
+    runtime = getattr(request.app.state, "runtime", None)
+    if runtime is None:
+        raise HTTPException(status_code=503, detail="MAIW runtime not available.")
+    svc = getattr(runtime, "copilot_service", None)
+    if svc is None:
+        raise HTTPException(
+            status_code=503,
+            detail="Copilot service not available. Ensure MAIW_DEMO_MODE=true and the runtime is initialized.",
+        )
+    return svc
+
+
+@router.post("/turn", response_model=CopilotTurnResponse)
+async def copilot_turn(body: CopilotTurnRequest, request: Request):
+    """
+    Process one Copilot operator turn.
+
+    Phase 15B: ASK intent only. ANALYZE and ACT will be enabled in 15C/15D.
+
+    The response contains zero ActionProposals, zero DecisionEngine evaluations,
+    and zero warehouse mutations for ASK turns.
+    """
+    svc = _get_copilot_service(request)
+
+    try:
+        result, turn = await svc.ask(
+            message=body.message,
+            conversation_id=body.conversation_id,
+            warehouse_id=body.warehouse_id,
+            scenario_name=body.scenario_name,
+        )
+    except Exception as exc:
+        logger.error("copilot_turn: unexpected error — %s", exc)
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+    return CopilotTurnResponse(
+        conversation_id=turn.conversation_id,
+        turn_id=turn.turn_id,
+        trace_id=turn.trace_id,
+        intent=turn.intent.value,
+        status="degraded" if result.degraded else "complete",
+        answer=result.answer,
+        evidence=[
+            {"label": e.label, "value": e.value, "severity": e.severity}
+            for e in result.evidence
+        ],
+        neighborhood={
+            "focus_entity_id": result.neighborhood.focus_entity_id,
+            "focus_entity_label": result.neighborhood.focus_entity_label,
+            "entity_count": len(result.neighborhood.entity_ids),
+            "relationship_summary": result.neighborhood.relationship_summary,
+            "graph_available": result.neighborhood.graph_available,
+        },
+        agent=result.agent,
+        skills_used=result.skills_used,
+        model_id=result.model_id,
+        reasoning_level=result.reasoning_level,
+        routing_rule=result.routing_rule,
+        routing_reason=result.routing_reason,
+        latency_ms=result.latency_ms,
+        degraded=result.degraded,
+        degradation_reason=result.degradation_reason,
+        related_artifacts={},
+    )

--- a/apps/api/tests/test_copilot_ask.py
+++ b/apps/api/tests/test_copilot_ask.py
@@ -1,0 +1,666 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""
+Phase 15B — Copilot ASK tests.
+
+Covers
+------
+1. Architecture invariants (import guards, forbidden paths)
+2. CopilotIntent enum
+3. CopilotTurn identity model
+4. InMemoryCopilotStore
+5. ASK turn — green path (mocked agent + state)
+6. ASK turn — state unavailable → explicit degradation (no simulated data)
+7. ASK turn — graph unavailable → degradation noted, still answers
+8. ASK turn — agent error → explicit error response
+9. Context size bounds (max_entities enforced)
+10. Evidence extraction from assessment facts
+
+All tests confirm zero ActionProposals, zero DecisionEngine calls, zero writes.
+"""
+
+from __future__ import annotations
+
+import importlib
+import inspect
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from maiw_api.copilot.models import (
+    CopilotAskResult,
+    CopilotConversation,
+    CopilotIntent,
+    CopilotTurn,
+    ContextNeighborhood,
+    EvidenceFact,
+)
+from maiw_api.copilot.service import CopilotService, _facts_to_evidence
+from maiw_api.copilot.store import InMemoryCopilotStore
+
+
+# ── Fixtures ───────────────────────────────────────────────────────────────────
+
+@dataclass
+class _FakeDomainState:
+    """Non-None placeholder so _get_state doesn't flag domains as missing."""
+    pass
+
+
+@dataclass
+class _FakeState:
+    warehouse_id: str = "DC-47"
+    equipment: Any = None
+    labor: Any = None
+    waves: Any = None
+
+    def __post_init__(self):
+        # Default to non-None so the service doesn't degrade on missing domains
+        if self.equipment is None:
+            self.equipment = _FakeDomainState()
+        if self.labor is None:
+            self.labor = _FakeDomainState()
+        if self.waves is None:
+            self.waves = _FakeDomainState()
+
+    def is_empty(self) -> bool:
+        return False
+
+
+@dataclass
+class _FakeSnapshot:
+    snapshot_id: str
+    warehouse_id: str
+    state: Any
+
+    @classmethod
+    def seal(cls, state: Any) -> "_FakeSnapshot":
+        return cls(snapshot_id=str(uuid.uuid4()), warehouse_id=state.warehouse_id, state=state)
+
+
+@dataclass
+class _FakeAssessment:
+    trace_id: str
+    snapshot_id: str
+    warehouse_id: str
+    summary: str = "Wave 17 is primarily constrained by labor availability."
+    severity: str = "high"
+    facts_observed: list = None
+    skills_consulted: list = None
+    recommendations: list = None
+    model_id: str = "nvidia/nemotron-3-nano-30b-a3b"
+    routing_rule: str = "medium_reasoning"
+    routing_reason: str = "Copilot ASK — MEDIUM reasoning"
+    latency_ms: float = 312.5
+
+    def __post_init__(self):
+        if self.facts_observed is None:
+            self.facts_observed = [
+                "Labor: 120 total, 40 available, 67% utilization",
+                "Wave tasks: 120 total, 5 pending, 8 in_progress, 3 at-risk",
+                "Equipment: 24 total, 24 available",
+                "UNASSIGNED PENDING TASKS: 5 pending wave tasks have no worker allocated",
+            ]
+        if self.skills_consulted is None:
+            self.skills_consulted = ["warehouse.labor.get_capacity", "warehouse.wave.get_state"]
+        if self.recommendations is None:
+            self.recommendations = []
+
+
+def _make_agent(assessment: _FakeAssessment | None = None) -> MagicMock:
+    agent = MagicMock()
+    agent.analyze_disruption = AsyncMock(
+        return_value=assessment or _FakeAssessment(
+            trace_id="trace-1", snapshot_id="snap-1", warehouse_id="DC-47"
+        )
+    )
+    return agent
+
+
+def _make_state_provider(state: Any = None, raises: Exception | None = None) -> MagicMock:
+    provider = MagicMock()
+    if raises:
+        provider.get_state = AsyncMock(side_effect=raises)
+    else:
+        provider.get_state = AsyncMock(return_value=state or _FakeState())
+    return provider
+
+
+def _make_mock_graph() -> MagicMock:
+    """Minimal mock graph — returns one wave entity, no neighbors."""
+    graph = MagicMock()
+    wave_entity = MagicMock()
+    wave_entity.entity_id = "WAVE-DC47-001"
+    wave_entity.wave_number = 17
+    graph.entities_by_type.return_value = [wave_entity]
+    graph.neighbors.return_value = []
+    graph.outgoing_edges.return_value = []
+    graph.incoming_edges.return_value = []
+    return graph
+
+
+def _make_service(
+    agent=None,
+    state_provider=None,
+    graph=None,
+    raises_state: Exception | None = None,
+    include_graph: bool = True,
+) -> CopilotService:
+    return CopilotService(
+        operations_agent=agent or _make_agent(),
+        state_provider=state_provider or _make_state_provider(raises=raises_state),
+        event_bus=None,
+        graph=graph if graph is not None else (_make_mock_graph() if include_graph else None),
+    )
+
+
+# ── 1. Architecture invariants ─────────────────────────────────────────────────
+
+class TestArchitectureInvariants:
+    """These tests protect the Copilot trust boundary."""
+
+    def test_copilot_service_does_not_import_action_executor(self):
+        """CopilotService must not import ActionExecutor — trust boundary."""
+        import maiw_api.copilot.service as svc_module
+
+        # Check actual imports, not docstring text
+        imports = {name for name in dir(svc_module) if not name.startswith("_")}
+        assert "ActionExecutor" not in imports, (
+            "CopilotService MUST NOT import ActionExecutor"
+        )
+        # Also verify no 'from ... import ActionExecutor' lines exist in code
+        lines = inspect.getsource(svc_module).splitlines()
+        import_lines = [l for l in lines if l.strip().startswith(("import ", "from "))]
+        assert not any("ActionExecutor" in l for l in import_lines)
+
+    def test_copilot_service_does_not_import_approval_store(self):
+        """CopilotService must not import ApprovalStore."""
+        import maiw_api.copilot.service as svc_module
+
+        lines = inspect.getsource(svc_module).splitlines()
+        import_lines = [l for l in lines if l.strip().startswith(("import ", "from "))]
+        assert not any("ApprovalStore" in l for l in import_lines)
+
+    def test_copilot_service_does_not_import_decision_engine(self):
+        """CopilotService must not import DecisionEngine."""
+        import maiw_api.copilot.service as svc_module
+
+        lines = inspect.getsource(svc_module).splitlines()
+        import_lines = [l for l in lines if l.strip().startswith(("import ", "from "))]
+        assert not any("DecisionEngine" in l for l in import_lines)
+
+    def test_copilot_service_has_no_evaluate_call(self):
+        """CopilotService must not call .evaluate() on any decision engine."""
+        import maiw_api.copilot.service as svc_module
+
+        lines = inspect.getsource(svc_module).splitlines()
+        # Exclude comment/docstring lines
+        code_lines = [l for l in lines if not l.strip().startswith("#") and '"""' not in l]
+        assert not any("engine.evaluate(" in l or "decision_engine.evaluate(" in l
+                       for l in code_lines)
+
+    def test_copilot_service_has_no_approve_call(self):
+        """CopilotService must not call approval_store.approve()."""
+        import maiw_api.copilot.service as svc_module
+
+        lines = inspect.getsource(svc_module).splitlines()
+        code_lines = [l for l in lines if not l.strip().startswith("#") and '"""' not in l]
+        assert not any(".approve(" in l for l in code_lines)
+
+    def test_copilot_router_has_no_approve_endpoint(self):
+        """The copilot router must not register a /approve route."""
+        import maiw_api.routers.copilot as router_module
+        from fastapi import APIRouter
+
+        # Check registered routes on the router object
+        route_paths = [r.path for r in router_module.router.routes]
+        assert not any("approve" in p for p in route_paths), (
+            f"Copilot router MUST NOT have /approve endpoint — found: {route_paths}"
+        )
+
+    def test_copilot_router_has_no_execute_endpoint(self):
+        """The copilot router must not register a /execute route."""
+        import maiw_api.routers.copilot as router_module
+
+        route_paths = [r.path for r in router_module.router.routes]
+        assert not any("execute" in p for p in route_paths), (
+            f"Copilot router MUST NOT have /execute endpoint — found: {route_paths}"
+        )
+
+    def test_copilot_router_has_no_force_action_endpoint(self):
+        import maiw_api.routers.copilot as router_module
+
+        route_paths = [r.path for r in router_module.router.routes]
+        assert not any("force" in p for p in route_paths)
+
+
+# ── 2. CopilotIntent enum ──────────────────────────────────────────────────────
+
+class TestCopilotIntent:
+    def test_intent_values(self):
+        assert CopilotIntent.ASK.value == "ask"
+        assert CopilotIntent.ANALYZE.value == "analyze"
+        assert CopilotIntent.ACT.value == "act"
+
+    def test_intent_is_str_subclass(self):
+        assert isinstance(CopilotIntent.ASK, str)
+        assert CopilotIntent.ASK == "ask"
+
+    def test_intent_enum_count(self):
+        # Phase 15B: exactly 3 intents. SIMULATE not yet added.
+        assert len(CopilotIntent) == 3
+
+    def test_no_simulate_intent_yet(self):
+        intent_values = {i.value for i in CopilotIntent}
+        assert "simulate" not in intent_values
+
+
+# ── 3. Conversation identity model ────────────────────────────────────────────
+
+class TestConversationIdentity:
+    def test_turn_has_distinct_ids(self):
+        turn = CopilotTurn(
+            turn_id="T1",
+            conversation_id="C1",
+            user_message="Why is Wave 17 at risk?",
+            intent=CopilotIntent.ASK,
+            created_at=datetime.now(timezone.utc),
+            trace_id="R1",
+            response_summary="answer",
+        )
+        # Three distinct IDs
+        assert turn.turn_id != turn.conversation_id
+        assert turn.turn_id != turn.trace_id
+        assert turn.conversation_id != turn.trace_id
+
+    def test_turn_stores_no_hidden_reasoning(self):
+        """CopilotTurn must not have chain_of_thought, scratchpad, hidden_reasoning."""
+        fields = {f.name for f in CopilotTurn.__dataclass_fields__.values()}
+        forbidden = {"chain_of_thought", "scratchpad", "hidden_reasoning", "reasoning_tokens"}
+        assert not fields & forbidden, f"Forbidden fields present: {fields & forbidden}"
+
+    def test_conversation_links_trace_ids(self):
+        conv = CopilotConversation(
+            conversation_id="C1",
+            warehouse_id="DC-47",
+            scenario_name="labor_constraint",
+        )
+        turn1 = CopilotTurn(
+            turn_id="T1", conversation_id="C1", user_message="q1",
+            intent=CopilotIntent.ASK, created_at=datetime.now(timezone.utc),
+            trace_id="R1", response_summary="a1",
+        )
+        turn2 = CopilotTurn(
+            turn_id="T2", conversation_id="C1", user_message="q2",
+            intent=CopilotIntent.ASK, created_at=datetime.now(timezone.utc),
+            trace_id="R2", response_summary="a2",
+        )
+        conv.add_turn(turn1)
+        conv.add_turn(turn2)
+
+        assert len(conv.turns) == 2
+        assert "R1" in conv.related_trace_ids
+        assert "R2" in conv.related_trace_ids
+        # trace_ids must stay distinct across turns
+        assert "R1" != "R2"
+
+
+# ── 4. InMemoryCopilotStore ───────────────────────────────────────────────────
+
+class TestInMemoryCopilotStore:
+    def test_create_and_get_conversation(self):
+        store = InMemoryCopilotStore()
+        conv = store.create_conversation("DC-47", "labor_constraint")
+        assert conv.conversation_id is not None
+        fetched = store.get_conversation(conv.conversation_id)
+        assert fetched is conv
+
+    def test_get_or_create_with_existing_id(self):
+        store = InMemoryCopilotStore()
+        conv = store.create_conversation("DC-47", "")
+        same = store.get_or_create(conv.conversation_id, "DC-47", "")
+        assert same is conv
+
+    def test_get_or_create_new_when_id_none(self):
+        store = InMemoryCopilotStore()
+        conv = store.get_or_create(None, "DC-47", "labor_constraint")
+        assert conv.conversation_id is not None
+
+    def test_add_turn_populates_conversation(self):
+        store = InMemoryCopilotStore()
+        conv = store.create_conversation("DC-47", "")
+        turn = CopilotTurn(
+            turn_id="T1", conversation_id=conv.conversation_id, user_message="q",
+            intent=CopilotIntent.ASK, created_at=datetime.now(timezone.utc),
+            trace_id="R1", response_summary="a",
+        )
+        store.add_turn(turn)
+        assert len(store.get_conversation(conv.conversation_id).turns) == 1
+
+    def test_reset_clears_all(self):
+        store = InMemoryCopilotStore()
+        store.create_conversation("DC-47", "")
+        store.reset()
+        assert store.get_conversation("anything") is None
+
+
+# ── 5. ASK turn — green path ──────────────────────────────────────────────────
+
+class TestAskGreenPath:
+    @pytest.mark.asyncio
+    async def test_ask_returns_answer(self):
+        with patch("maiw_api.copilot.service.WarehouseStateSnapshot") as mock_snap:
+            mock_snap.seal.return_value = _FakeSnapshot.seal(_FakeState())
+            svc = _make_service()
+            result, turn = await svc.ask(
+                message="Why is Wave 17 at risk?",
+                conversation_id=None,
+                warehouse_id="DC-47",
+            )
+
+        assert result.answer == "Wave 17 is primarily constrained by labor availability."
+        assert result.degraded is False
+        assert result.trace_id == turn.trace_id
+        assert turn.intent == CopilotIntent.ASK
+
+    @pytest.mark.asyncio
+    async def test_ask_produces_zero_action_proposals(self):
+        """ASK turn must never return an ActionProposal."""
+        with patch("maiw_api.copilot.service.WarehouseStateSnapshot") as mock_snap:
+            mock_snap.seal.return_value = _FakeSnapshot.seal(_FakeState())
+            svc = _make_service()
+            result, turn = await svc.ask(
+                message="Why is Wave 17 at risk?",
+                conversation_id=None,
+                warehouse_id="DC-47",
+            )
+
+        assert not hasattr(result, "proposal") or result.__class__.__name__ == "CopilotAskResult"
+        # CopilotAskResult must not have proposal/decision/approval/execution fields
+        result_fields = set(vars(result).keys())
+        forbidden = {"proposal", "decision", "approval", "execution"}
+        assert not result_fields & forbidden
+
+    @pytest.mark.asyncio
+    async def test_ask_does_not_call_decision_engine(self):
+        decision_engine = MagicMock()
+        decision_engine.evaluate = MagicMock()
+        with patch("maiw_api.copilot.service.WarehouseStateSnapshot") as mock_snap:
+            mock_snap.seal.return_value = _FakeSnapshot.seal(_FakeState())
+            svc = _make_service()
+            await svc.ask(
+                message="Why is Wave 17 at risk?",
+                conversation_id=None,
+                warehouse_id="DC-47",
+            )
+        decision_engine.evaluate.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_ask_passes_medium_reasoning_to_agent(self):
+        """Copilot expresses ReasoningLevel.MEDIUM for ASK; ModelGateway selects model."""
+        agent = _make_agent()
+        with patch("maiw_api.copilot.service.WarehouseStateSnapshot") as mock_snap:
+            mock_snap.seal.return_value = _FakeSnapshot.seal(_FakeState())
+            svc = _make_service(agent=agent)
+            await svc.ask(
+                message="Why is Wave 17 at risk?",
+                conversation_id=None,
+                warehouse_id="DC-47",
+            )
+
+        call_kwargs = agent.analyze_disruption.call_args.kwargs
+        from maiw_models import ReasoningLevel, RiskLevel
+        assert call_kwargs["reasoning_level"] == ReasoningLevel.MEDIUM
+        assert call_kwargs["risk_level"] == RiskLevel.LOW
+
+    @pytest.mark.asyncio
+    async def test_ask_threads_trace_id_to_agent(self):
+        agent = _make_agent()
+        with patch("maiw_api.copilot.service.WarehouseStateSnapshot") as mock_snap:
+            mock_snap.seal.return_value = _FakeSnapshot.seal(_FakeState())
+            svc = _make_service(agent=agent)
+            result, turn = await svc.ask(
+                message="Why is Wave 17 at risk?",
+                conversation_id=None,
+                warehouse_id="DC-47",
+            )
+
+        call_kwargs = agent.analyze_disruption.call_args.kwargs
+        assert call_kwargs["trace_id"] == result.trace_id == turn.trace_id
+
+    @pytest.mark.asyncio
+    async def test_ask_stores_turn_in_conversation(self):
+        with patch("maiw_api.copilot.service.WarehouseStateSnapshot") as mock_snap:
+            mock_snap.seal.return_value = _FakeSnapshot.seal(_FakeState())
+            svc = _make_service()
+            result, turn = await svc.ask(
+                message="Why is Wave 17 at risk?",
+                conversation_id=None,
+                warehouse_id="DC-47",
+            )
+
+        conv = svc.store.get_conversation(turn.conversation_id)
+        assert conv is not None
+        assert len(conv.turns) == 1
+        assert conv.turns[0].turn_id == turn.turn_id
+
+    @pytest.mark.asyncio
+    async def test_ask_includes_structured_evidence(self):
+        with patch("maiw_api.copilot.service.WarehouseStateSnapshot") as mock_snap:
+            mock_snap.seal.return_value = _FakeSnapshot.seal(_FakeState())
+            svc = _make_service()
+            result, _ = await svc.ask(
+                message="Why is Wave 17 at risk?",
+                conversation_id=None,
+                warehouse_id="DC-47",
+            )
+
+        assert len(result.evidence) > 0
+        assert all(isinstance(e, EvidenceFact) for e in result.evidence)
+        # Labor fact should be in evidence
+        labels = [e.label for e in result.evidence]
+        assert any("Labor" in label or "labor" in label for label in labels)
+
+    @pytest.mark.asyncio
+    async def test_ask_includes_model_metadata(self):
+        with patch("maiw_api.copilot.service.WarehouseStateSnapshot") as mock_snap:
+            mock_snap.seal.return_value = _FakeSnapshot.seal(_FakeState())
+            svc = _make_service()
+            result, _ = await svc.ask(
+                message="Why is Wave 17 at risk?",
+                conversation_id=None,
+                warehouse_id="DC-47",
+            )
+
+        assert result.reasoning_level == "MEDIUM"
+        assert result.model_id is not None
+        assert result.routing_rule is not None
+
+
+# ── 6. ASK turn — state unavailable → explicit degradation ───────────────────
+
+class TestAskDegradation:
+    @pytest.mark.asyncio
+    async def test_state_provider_none_degrades_explicitly(self):
+        svc = CopilotService(
+            operations_agent=_make_agent(),
+            state_provider=None,  # unavailable
+            event_bus=None,
+            graph=None,
+        )
+        result, turn = await svc.ask(
+            message="Why is Wave 17 at risk?",
+            conversation_id=None,
+            warehouse_id="DC-47",
+        )
+        assert result.degraded is True
+        assert result.degradation_reason is not None
+        assert "unavailable" in result.degradation_reason.lower()
+        # Must not be an empty answer
+        assert len(result.answer) > 0
+        # Must not be simulated data
+        assert "John Smith" not in result.answer
+        assert "Sarah Johnson" not in result.answer
+
+    @pytest.mark.asyncio
+    async def test_state_provider_exception_degrades_explicitly(self):
+        svc = _make_service(raises_state=RuntimeError("PostgreSQL connection refused"))
+        result, turn = await svc.ask(
+            message="Why is Wave 17 at risk?",
+            conversation_id=None,
+            warehouse_id="DC-47",
+        )
+        assert result.degraded is True
+        assert "PostgreSQL" in result.degradation_reason or "assembled" in result.degradation_reason
+        assert len(result.answer) > 0
+
+    @pytest.mark.asyncio
+    async def test_state_unavailable_returns_no_simulated_names(self):
+        """When state is unavailable, must not return invented person names."""
+        svc = CopilotService(
+            operations_agent=_make_agent(),
+            state_provider=None,
+            event_bus=None,
+            graph=None,
+        )
+        result, _ = await svc.ask(
+            message="How many workers are available?",
+            conversation_id=None,
+            warehouse_id="DC-47",
+        )
+        simulated_names = ["John Smith", "Sarah Johnson", "Mike Wilson", "Lisa Brown"]
+        for name in simulated_names:
+            assert name not in result.answer
+
+    @pytest.mark.asyncio
+    async def test_graph_unavailable_noted_but_state_still_used(self):
+        """If graph is None but state is available, answer is still provided."""
+        with patch("maiw_api.copilot.service.WarehouseStateSnapshot") as mock_snap:
+            mock_snap.seal.return_value = _FakeSnapshot.seal(_FakeState())
+            svc = _make_service(include_graph=False)  # no graph
+            result, _ = await svc.ask(
+                message="Why is Wave 17 at risk?",
+                conversation_id=None,
+                warehouse_id="DC-47",
+            )
+
+        # Still answers from WarehouseState
+        assert result.answer == "Wave 17 is primarily constrained by labor availability."
+        # Neighborhood degrades gracefully
+        assert result.neighborhood.graph_available is False
+        # degraded=True because graph was unavailable
+        assert result.degraded is True
+        assert "Graph" in (result.degradation_reason or "") or "graph" in (result.degradation_reason or "").lower()
+
+
+# ── 7. ASK turn — agent error ─────────────────────────────────────────────────
+
+class TestAskAgentError:
+    @pytest.mark.asyncio
+    async def test_agent_error_returns_explicit_error_response(self):
+        agent = MagicMock()
+        agent.analyze_disruption = AsyncMock(side_effect=RuntimeError("NIM timeout"))
+        with patch("maiw_api.copilot.service.WarehouseStateSnapshot") as mock_snap:
+            mock_snap.seal.return_value = _FakeSnapshot.seal(_FakeState())
+            svc = _make_service(agent=agent)
+            result, turn = await svc.ask(
+                message="Why is Wave 17 at risk?",
+                conversation_id=None,
+                warehouse_id="DC-47",
+            )
+
+        assert result.degraded is True
+        assert result.degradation_reason is not None
+        assert len(result.answer) > 0
+        # Must not be simulated
+        assert "John Smith" not in result.answer
+
+
+# ── 8. Context size bounds ────────────────────────────────────────────────────
+
+class TestContextBounds:
+    def test_max_entities_enforced(self):
+        """Context resolver must not return more than 50 entities."""
+        from maiw_api.copilot import context as ctx
+
+        # Build a mock graph with many neighbors
+        mock_graph = MagicMock()
+        mock_entity = MagicMock()
+        mock_entity.entity_id = "WAVE-01"
+        mock_entity.wave_number = 17
+
+        mock_neighbor = MagicMock()
+        mock_neighbor.entity_id = "WORKER-{i}"
+
+        # 200 neighbors — resolver must cap at 50
+        mock_graph.entities_by_type.return_value = [mock_entity]
+        many_neighbors = [MagicMock(entity_id=f"N-{i}") for i in range(200)]
+        mock_graph.neighbors.return_value = many_neighbors
+        mock_graph.outgoing_edges.return_value = []
+        mock_graph.incoming_edges.return_value = []
+
+        from maiw_world.entities import EntityType
+        result = ctx.resolve("Why is Wave 17 at risk?", "DC-47", mock_graph)
+
+        assert len(result.entity_ids) <= 50
+
+    def test_graph_none_returns_unavailable(self):
+        from maiw_api.copilot import context as ctx
+
+        result = ctx.resolve("Why is Wave 17 at risk?", "DC-47", None)
+        assert result.graph_available is False
+        assert result.focus_entity_id is None
+        assert result.entity_ids == []
+
+
+# ── 9. Evidence extraction ────────────────────────────────────────────────────
+
+class TestEvidenceExtraction:
+    def test_labor_fact_parsed(self):
+        facts = ["Labor: 120 total, 40 available, 67% utilization"]
+        evidence = _facts_to_evidence(facts, "high")
+        assert len(evidence) == 1
+        assert evidence[0].label == "Labor"
+        assert "67%" in evidence[0].value
+
+    def test_unassigned_tasks_flagged_high(self):
+        facts = ["UNASSIGNED PENDING TASKS: 5 pending wave tasks have no worker allocated"]
+        evidence = _facts_to_evidence(facts, "high")
+        assert len(evidence) == 1
+        assert evidence[0].severity == "HIGH"
+
+    def test_offline_equipment_flagged_high(self):
+        facts = ["OFFLINE assets: AGV-01, AGV-02"]
+        evidence = _facts_to_evidence(facts, "high")
+        assert evidence[0].severity == "HIGH"
+
+    def test_multiple_facts(self):
+        facts = [
+            "Labor: 120 total, 40 available, 67% utilization",
+            "Wave tasks: 120 total, 5 pending, 8 in_progress, 3 at-risk",
+            "Equipment: 24 total, 24 available",
+        ]
+        evidence = _facts_to_evidence(facts, "medium")
+        assert len(evidence) == 3
+
+
+# ── 10. CopilotAskResult has no mutation fields ───────────────────────────────
+
+class TestAskResultContract:
+    def test_ask_result_has_no_proposal_field(self):
+        fields = set(CopilotAskResult.__dataclass_fields__.keys())
+        assert "proposal" not in fields
+        assert "decision" not in fields
+        assert "approval" not in fields
+        assert "execution" not in fields
+
+    def test_ask_result_has_no_hidden_reasoning(self):
+        fields = set(CopilotAskResult.__dataclass_fields__.keys())
+        assert "chain_of_thought" not in fields
+        assert "scratchpad" not in fields
+        assert "hidden_reasoning" not in fields
+        assert "reasoning_tokens" not in fields

--- a/docs/demo/PHASE_14G_UI_WORKFLOW.md
+++ b/docs/demo/PHASE_14G_UI_WORKFLOW.md
@@ -1,0 +1,156 @@
+# Phase 14G — MAIW Demo UI Workflow
+
+## Overview
+
+Phase 14G hardens the MAIW v2 demo UI for reliable stakeholder demonstrations. It does not add new agents, capabilities, or model routes. It makes the existing end-to-end demo workflow robust, self-explanatory, and safe to operate.
+
+## Quick Start
+
+1. Ensure the MAIW API backend is running on port 8000
+2. Start the frontend dev server: `cd src/ui/web && npm start`
+3. Navigate to `http://localhost:3000` (defaults to `/demo`)
+4. Select a scenario and click Start
+5. Run MAIW Analysis when prompted
+6. Follow the lifecycle rail: OBSERVE → REASON → PROPOSE → DECIDE → APPROVE → EXECUTE → OUTCOME
+
+## Demo Shell Layout
+
+### Top Navigation Bar
+
+- **MAIW Command Center** — product identity (always visible)
+- **Synthetic demo** — DEMO MODE badge (always visible)
+- **Warehouse ID** — shown in the state strip (from `REACT_APP_WAREHOUSE_ID` or `DC-47`)
+- **Copilot / Phase 15** — disabled entry point; labeled "Coming in Phase 15". Not functional.
+- **Operations / Reliability** — mode switcher for main view vs. reliability view
+- **Expert** — toggles the expert overlay (trace, runtime, raw JSON)
+
+### State Strip
+
+Shows in real time:
+- `warehouse_id` — operational identity
+- State freshness — FRESH (< 60s) / STALE (> 120s) / color-coded
+- System status — HEALTHY / DEGRADED / UNKNOWN from runtime status API
+
+### System Footer
+
+- System status with color + text indicator (never color alone)
+- Safety invariant status — changes to `! Review required` if RECONCILIATION_REQUIRED event received
+- SSE live connection status — shown when a scenario is active
+- Details link (future expansion)
+
+## Demo Workflow Step by Step
+
+### Step 1 — Select Scenario
+
+When no scenario is active the ScenarioSelector renders. Recommended scenario: `labor_constraint_wave_risk` (marked with blue border).
+
+Scenarios are fetched from `GET /api/v1/demo/scenarios`. If the backend is unavailable, a `BackendErrorBanner` appears with a **Retry connection** button.
+
+### Step 2 — Start Scenario
+
+Click **Start**. The frontend calls `POST /api/v1/demo/scenario/{name}/start`. The lifecycle rail appears and SSE connection activates.
+
+### Step 3 — OBSERVE (Warehouse State Assembly)
+
+The default view shows:
+- **Warehouse Snapshot** — equipment/workers/tasks/inventory grid from `demoStatus.world`
+- **Operational Context** — equipment %, labor %, backlog, wave risk from `demoStatus.current_kpis`
+- **State freshness** — seconds since last snapshot from `current_kpis.state_freshness_seconds`
+
+Click **▶ Run MAIW Analysis** to trigger the full pipeline.
+
+### Step 4 — REASON, PROPOSE, DECIDE
+
+After analysis completes, the lifecycle rail advances. Each stage shows:
+- **REASON** — assessment summary, facts observed, severity, domains affected
+- **PROPOSE** — recommended capabilities with domain, target, rationale, risk level
+- **DECIDE** — policy result, routing rule, model used, latency
+
+All data comes from `analysisResult` returned by `POST /api/v1/demo/analyze`.
+
+### Step 5 — APPROVE (Human Governance)
+
+If the policy engine requires approval, an **ApprovalCard** appears showing:
+- Proposed action and operational target
+- Why (rationale from the decision engine)
+- Facts from the observe phase
+- State validity (freshness + proposal_id + decision_id)
+- Risk level badge
+- **APPROVE & EXECUTE** and **REJECT** buttons
+
+Approval buttons are disabled after click — duplicate submission is prevented by the backend identity (pending_id). A 404 response indicates the approval was already consumed.
+
+Expired approvals (> 10 minutes) disable both buttons and show an EXPIRED badge.
+
+### Step 6 — EXECUTE
+
+After approval, the ActionExecutor runs. ExecuteStage shows:
+- Capability executed and execution_id
+- Outcome badge: EXECUTED / NO_OP / DEFERRED / CONFLICT / UNKNOWN / FAILED
+- **UNKNOWN** outcome triggers a reconciliation notice — the warehouse state is uncertain and automatic retry is suppressed
+
+### Step 7 — OUTCOME
+
+OutcomeStage shows:
+- OBSERVED OPERATIONAL IMPACT (not projected) — pre/post KPI deltas
+- Wave Risk, Pending Backlog, Wave Completion, Throughput, Labor Utilization
+- Time to recovery (if reached)
+- Trend chart from `kpi_history`
+- **RUN ANOTHER SCENARIO** button → calls `handleReset()`
+
+### Resetting
+
+Click **Reset** in the scenario header or RUN ANOTHER SCENARIO in OutcomeStage. This:
+1. Shows ScenarioSelector immediately (no wait for poll)
+2. Clears SSE event buffer
+3. Clears analysis result
+4. Calls `POST /api/v1/demo/scenario/reset`
+
+## Error and Recovery States
+
+| Error Condition | What the UI Shows |
+|---|---|
+| Initial load | Spinner + "Connecting to demo backend..." with `role="status"` |
+| Backend unavailable | `BackendErrorBanner` with Retry button, `role="alert"` |
+| No scenario active | ScenarioSelector with instructional text |
+| SSE disconnected | Footer shows amber "Reconnecting" chip |
+| Analysis in progress | Spinner in Run Analysis button, disabled state |
+| Approval expired | EXPIRED badge, buttons disabled |
+| Approval consumed (404) | CONSUMED outcome badge in card |
+| Execution unknown | UNKNOWN badge + reconciliation notice |
+| Execution failed | FAILED badge in ExecCard |
+
+No blank screens. No raw error objects. No endless spinners. Every error state has an actionable path forward.
+
+## Trust Boundary
+
+The UI makes the following boundaries explicit and visible:
+
+```
+Agent/model → analyzes/proposes (reason/propose stages)
+WarehouseState → operational truth (observe stage)
+DecisionEngine → policy evaluation (decide stage)
+Human → approves when required (approve stage)
+ActionExecutor → executes (execute stage)
+Runtime → confirms outcome (outcome stage)
+```
+
+- The model never directly authorizes or executes warehouse actions
+- "HUMAN APPROVAL REQUIRED" is shown prominently on every approval card
+- The Copilot entry point is disabled and labeled "Coming in Phase 15"
+
+## Viewports
+
+Optimized for:
+- 1440×900 (primary)
+- 1280×800
+
+Dense tables use contained horizontal scrolling within their card containers.
+
+## Running Tests
+
+```bash
+cd src/ui/web && npm test -- --watchAll=false
+```
+
+Phase 14G baseline: 500 tests, 23 suites.

--- a/docs/developer/PHASE_15_COPILOT_ARCHITECTURE.md
+++ b/docs/developer/PHASE_15_COPILOT_ARCHITECTURE.md
@@ -1,0 +1,508 @@
+# Phase 15 — MAIW Copilot Architecture
+
+> Supersedes `PHASE_15_COPILOT_INTEGRATION.md` (Phase 14G stub).
+
+Copilot is the human-interaction layer over MAIW's existing operational intelligence and governed decision architecture. It is not a warehouse agent and not an execution engine.
+
+---
+
+## Trust Boundary (Non-Negotiable)
+
+```
+Operator Input
+      ↓
+MAIW Copilot  ← intent, grounding, orchestration ONLY
+      ↓
+  ASK path  → WarehouseState + Operational Graph → Agent → ModelGateway → Nemotron → Skills → Grounded Answer
+  ANALYZE   → same path → Assessment + Recommendations (no mutation)
+  ACT path  → same path → ActionProposal → DecisionEngine → Human Approval → ActionExecutor → MCP → Warehouse → Outcome
+```
+
+**Copilot may request intelligence and propose governed actions.**
+**Copilot must never become an alternative approval or execution path.**
+**`POST /copilot/approve` and `POST /copilot/execute` must never exist.**
+
+---
+
+## Intent Model
+
+```python
+class CopilotIntent(str, Enum):
+    ASK     = "ask"      # read-only explanation
+    ANALYZE = "analyze"  # assessment + recommendation, no mutation
+    ACT     = "act"      # ActionProposal → governed lifecycle
+```
+
+SIMULATE is reserved for a future phase. Do not implement it in Phase 15.
+
+Intent is inferred, not operator-selected. Deterministic rules first; ModelGateway structured classifier only for ambiguous cases.
+
+**Safety invariant:** No natural-language phrasing routes directly to execution. "Move 3 workers to Wave 17 now." → `ACT → ActionProposal → DecisionEngine` — never `execute()`.
+
+If intent is ambiguous (e.g., "Take care of Wave 17"), Copilot asks a clarification:
+```
+Do you want me to: (1) explain the risk, (2) recommend an action, or (3) prepare the recommended action for approval?
+```
+
+---
+
+## Conversation Identity
+
+Three distinct IDs — not the same thing:
+
+| ID | Scope | Lifecycle |
+|---|---|---|
+| `conversation_id` | One operator Copilot session | Created when drawer opens; persists until reset/close |
+| `turn_id` | One operator message + Copilot response | `uuid4()` at turn ingress |
+| `trace_id` | One MAIW reasoning/decision execution | `uuid4()` at turn ingress; threaded to ModelGateway + Proposal + Decision + Execution |
+
+A three-turn conversation:
+```
+conversation_id = C1
+  Turn 1  turn_id=T1  trace_id=R1  ASK
+  Turn 2  turn_id=T2  trace_id=R2  ANALYZE
+  Turn 3  turn_id=T3  trace_id=R3  ACT
+```
+
+Each turn is a separate trace. Turns are linked by `parent_turn_id` and `related_trace_ids[]`.
+
+---
+
+## Agent Contract (Confirmed by Audit)
+
+**Primary entry point: `OperationsCoordinationAgent.process_query(query, session_id, context)`**
+
+No new `CopilotAgent` is required.
+
+`process_query` already:
+- accepts free-text natural-language intent
+- maintains per-session conversation history by `session_id`
+- accepts `context: Dict[str, Any]` for injecting warehouse state facts
+- returns `OperationsResponse` with `natural_language` + `recommendations`
+
+**Thin adapter needed:**
+1. Map `conversation_id` → `session_id`
+2. Serialize `WarehouseState` summary into `context["warehouse_state"]`
+3. Thread `trace_id` through `context["trace_id"]` (since `process_query` does not natively accept it as a kwarg)
+4. Wrap `OperationsResponse` in `CopilotTurn` response shape
+
+`analyze_disruption` (the demo pipeline entry point) is NOT the Copilot path — it does not accept free-text intent and assumes a pre-sealed snapshot. It remains the `/demo/analyze` path only.
+
+---
+
+## ModelGateway Contract
+
+`ModelRequest` fields relevant to Copilot:
+
+| Field | Copilot Use |
+|---|---|
+| `task` | `"warehouse.operations.analyze_disruption"` (reuse for ANALYZE/ACT); suggest `"warehouse.copilot.ask"` for ASK if routing needs differentiation |
+| `messages` | `[{"role": "system", ...}, {"role": "user", "content": operator_message}]` |
+| `reasoning` | `ReasoningLevel.HIGH` for ACT; `MEDIUM` for ASK/ANALYZE |
+| `risk_level` | `RiskLevel.LOW` for ASK/ANALYZE; `HIGH` for ACT |
+| `trace_id` | **Always set** from Copilot turn's `trace_id` |
+| `deadline` | Reuse existing `RequestDeadline` from Phase 10E deadline architecture |
+
+**No structured output.** No Nemotron model confirmed JSON mode. All response parsing uses regex/markdown extraction with JSON `try/except` fallback.
+
+**Routing outcomes:**
+- ASK (MEDIUM reasoning) → `nano` model
+- ANALYZE (MEDIUM reasoning) → `nano` model
+- ACT (HIGH reasoning, HIGH risk) → `super` model
+
+---
+
+## Operational Context Architecture
+
+Every Copilot turn grounds itself in current state. The context resolver is the boundary between "all of DC-47" and "what Nemotron sees."
+
+```python
+@dataclass
+class OperationalContext:
+    warehouse_id: str
+    snapshot_id: str
+    focus_entity_ids: list[str]
+    facts: list[str]             # human-readable fact strings (existing format)
+    relationships: list[dict]    # relevant edges: {from, rel_type, to}
+    domain_states: dict          # {labor: {...}, waves: {...}, equipment: {...}}
+```
+
+Resolution for "Why is Wave 17 at risk?":
+1. Identify focus entity from query text (Wave 17 → find entity by label)
+2. `graph.neighbors(wave_id, direction="both", depth=2)` → tasks, assigned workers, orders, carrier cutoffs, equipment
+3. `events_for_entity(wave_id)` → recent operational events
+4. Pull matching domain state from `WarehouseState` for confirmed entities
+5. Serialize to `OperationalContext` (not raw graph dicts)
+
+**Bounds:**
+- `max_depth = 2` (default)
+- `max_entities = 50`
+- `max_relationships = 100`
+
+These must be documented and enforced. Never pass full DataPack to Nemotron.
+
+---
+
+## Skill Inventory (Confirmed by Audit)
+
+### Read-Only (ASK / ANALYZE)
+| Skill | Input | Output |
+|---|---|---|
+| `LaborCapacitySkill` | `warehouse_id, zone?, shift?` | capacity utilization |
+| `LaborAllocationSkill` | `warehouse_id, worker_id?, zone?` | allocation state |
+| `WaveGetSkill` | `warehouse_id, wave_id?, zone?` | wave task state |
+| `WaveRiskSkill` | `warehouse_id, wave_id?, cutoff_minutes` | risk assessment |
+| `EquipmentStatusSkill` | `asset_id?, equipment_type?, zone?` | equipment status |
+| `EquipmentTelemetrySkill` | `asset_id, metric?, hours_back` | telemetry |
+| `InventoryLookupSkill` | `sku, warehouse_id` | inventory position |
+
+### Proposal-Building (ACT)
+| Skill | Produces |
+|---|---|
+| `ProposeLaborAllocationSkill` | `ActionProposal` — `warehouse.labor.allocate` |
+| `ProposeWaveReprioritizationSkill` | `ActionProposal` — `warehouse.wave.reprioritize` |
+| `EquipmentAssignmentSkill` | `ActionProposal` — `warehouse.equipment.assign` |
+
+All proposal-building skills are in-process only — no MCP write until post-approval execution.
+
+---
+
+## ASK Contract
+
+```python
+@dataclass
+class CopilotAskResult:
+    answer: str
+    evidence: list[str]          # fact strings from OperationalContext
+    entities_considered: list[str]
+    skills_used: list[str]
+    model_id: str
+    routing_rule: str
+    routing_reason: str
+    trace_id: str
+```
+
+ASK must NOT contain: `proposal`, `decision`, `approval`, `execution` — except historical references to prior turns.
+
+ASK cannot create an `ActionProposal`.
+
+---
+
+## ANALYZE Contract
+
+```python
+@dataclass
+class CopilotAnalyzeResult:
+    summary: str
+    severity: str                # LOW / MEDIUM / HIGH / CRITICAL
+    evidence: list[str]
+    recommendations: list[RecommendedAction]   # reuse existing type
+    skills_used: list[str]
+    model_id: str
+    routing_rule: str
+    routing_reason: str
+    trace_id: str
+```
+
+ANALYZE must NOT execute, approve, or mutate warehouse state.
+
+`RecommendedAction` already exists in `maiw_agents.assessment` — reuse it.
+
+---
+
+## ACT Contract
+
+```python
+@dataclass
+class CopilotActResult:
+    intent_confirmed: str        # "ACT"
+    action_description: str
+    proposal: ActionProposal
+    decision_outcome: str        # APPROVED / REJECTED / REQUIRES_HUMAN_APPROVAL / REQUIRES_FRESH_STATE
+    decision_id: str
+    approval_id: str | None      # set if REQUIRES_HUMAN_APPROVAL
+    execution: dict | None       # set if APPROVED and auto-executed
+    trace_id: str
+    state_drift_detected: bool
+```
+
+### Recommendation Resolution ("Do it.")
+Turn 3 resolves prior ANALYZE turn:
+1. Look up `last_recommendations` from `CopilotTurn` store by `conversation_id`
+2. Select `recommendations[0]` (or the operator-indicated index)
+3. **Revalidate** current `WarehouseState` — state may have drifted since Turn 2
+4. If material drift detected: inform operator, re-analyze before proposing
+5. If state is fresh: call appropriate `Propose*Skill` → `ActionProposal`
+6. Call `DecisionEngine.evaluate(DecisionRequest(..., trace_id=turn_trace_id))`
+7. Return `CopilotActResult` with decision outcome
+
+### State Drift Handling
+If relevant warehouse state changed materially between ANALYZE and ACT:
+```
+The warehouse state has changed since this recommendation was generated.
+I need to re-evaluate before preparing the action.
+```
+Then re-run ANALYZE with fresh state before creating the proposal.
+
+---
+
+## ActionProposal Boundary (Confirmed by Audit)
+
+Factory methods on `ActionProposal`:
+- `ActionProposal.for_labor_allocate(...)`
+- `ActionProposal.for_wave_reprioritize(...)`
+- `ActionProposal.for_equipment_assign(...)`
+
+**Always use factory methods. Never construct `ActionProposal` JSON manually in the API router.**
+
+`trace_id` flows: `CopilotTurn.trace_id` → `ActionProposal.trace_id` → `DecisionRequest.trace_id` → `DecisionResult.trace_id` → `ApprovalRecord.trace_id` → execution call.
+
+---
+
+## DecisionEngine Boundary (Confirmed by Audit)
+
+Every ACT-derived proposal must call `DecisionEngine.evaluate()`. No exception.
+
+Possible outcomes that Copilot must surface without collapsing:
+- `APPROVED` — proposal auto-approved (LOW risk or auto-approves); Copilot surfaces result
+- `REJECTED` — explain why; no retry without fresh state and operator re-confirmation
+- `REQUIRES_HUMAN_APPROVAL` — Copilot surfaces approval card; Copilot does NOT call `POST /demo/approve`
+- `REQUIRES_FRESH_STATE` — state was stale at decision time; revalidate and retry
+
+---
+
+## Human Approval Boundary (Confirmed by Audit)
+
+When `decision_outcome = REQUIRES_HUMAN_APPROVAL`:
+- Copilot enqueues to `ctrl.pending_approvals` (same store as the demo pipeline)
+- Copilot displays: "This action requires human approval." + existing approval card
+- **Copilot does NOT call `POST /demo/approve` automatically**
+- The operator must explicitly interact with the approval control
+- `POST /demo/approve` remains the only approval path
+
+---
+
+## Execution Boundary (Confirmed by Audit)
+
+Copilot never calls `ActionExecutor.execute()` directly from a conversational handler.
+
+If `DecisionEngine` returns `APPROVED` and the current architecture auto-executes (i.e., executor is present and bound), that canonical behavior is preserved — but it runs through `state_aware_ops.propose_*`, not through a Copilot-specific shortcut.
+
+---
+
+## Conversation Store
+
+Process-local, in-memory — same scope as `InMemoryApprovalStore`:
+
+```python
+@dataclass
+class CopilotTurn:
+    turn_id: str
+    conversation_id: str
+    user_message: str
+    intent: CopilotIntent
+    created_at: datetime
+    trace_id: str
+    response_summary: str
+    artifact_refs: dict           # {proposal_id, decision_id, approval_id, execution_id}
+
+@dataclass  
+class CopilotConversation:
+    conversation_id: str
+    warehouse_id: str
+    scenario_name: str
+    turns: list[CopilotTurn]
+    last_recommendations: list[RecommendedAction]
+    related_trace_ids: list[str]
+    created_at: datetime
+```
+
+Do NOT store: `chain_of_thought`, `scratchpad`, `hidden_reasoning`, `reasoning_tokens`.
+
+Process-local limitation must be documented in the API response.
+
+---
+
+## API Design
+
+Single endpoint:
+
+```
+POST /api/v1/copilot/turn
+```
+
+Request:
+```json
+{
+  "conversation_id": "...",
+  "message": "Why is Wave 17 at risk?",
+  "context": {}
+}
+```
+
+Response:
+```json
+{
+  "conversation_id": "C1",
+  "turn_id": "T1",
+  "trace_id": "R1",
+  "intent": "ask",
+  "status": "complete",
+  "response": {
+    "answer": "...",
+    "evidence": [...],
+    "entities_considered": [...],
+    "skills_used": ["wave.get_state", "labor.get_capacity"],
+    "model_id": "nvidia/nemotron-3-nano-...",
+    "routing_rule": "medium_reasoning",
+    "routing_reason": "..."
+  },
+  "related_artifacts": {}
+}
+```
+
+**Explicitly forbidden endpoints:**
+```
+/copilot/approve
+/copilot/execute
+/copilot/force-action
+```
+
+---
+
+## SSE / Developer Trace Integration
+
+Every Copilot turn generates a `trace_id` that flows into `ModelRequest.trace_id` and any downstream `ActionProposal.trace_id`. Copilot-initiated pipeline events (REASON, SKILL, PROPOSE, DECIDE, etc.) appear in the existing SSE stream with the matching `trace_id` in `detail`.
+
+New SSE categories (minimal additions to `EventCategory`):
+```python
+"COPILOT_TURN_STARTED"
+"COPILOT_INTENT_RESOLVED"
+"COPILOT_CONTEXT_RESOLVED"
+"COPILOT_TURN_COMPLETE"
+```
+
+These are NOT added to `SSE_TO_RAIL` — they are conversational events, not pipeline stages.
+
+The Copilot drawer filters the shared SSE event buffer by `trace_id` to show turn-specific pipeline activity. **No second `EventSource` connection.**
+
+---
+
+## UI Architecture
+
+Phase 14G reserved entry point: `data-testid="phase15-copilot-button"` — currently `disabled`. Enable by removing `disabled` / `aria-disabled`, adding `onClick` that opens the drawer.
+
+Layout (desktop):
+```
+Main MAIW Demo (~65–70%) │ Copilot Drawer (~30–35%)
+```
+
+Drawer structure:
+```
+MAIW COPILOT
+
+Context: DC-47 · Labor Constraint + Wave Risk
+────────────────
+[conversation turns]
+────────────────
+Suggested: [Why is the wave at risk?] [What should we do?]
+────────────────
+Ask MAIW…  [_________________________] [Send]
+```
+
+Copilot drawer shares the React Query client and SSE stream. It does not replace the stage workflow view.
+
+---
+
+## Developer Trace Shape (per turn)
+
+```
+COPILOT TURN (turn_id, conversation_id)
+      ↓ COPILOT_INTENT_RESOLVED
+Intent: ASK / ANALYZE / ACT
+      ↓ COPILOT_CONTEXT_RESOLVED
+WarehouseState snapshot
+Operational Graph neighborhood (entity_ids, depth)
+      ↓ REASON (existing)
+Agent: OperationsCoordinationAgent.process_query
+      ↓ MODEL (via ModelGateway routing)
+ModelGateway → nano / super
+      ↓ SKILL (existing, per skill invocation)
+Skills: wave.get_state, labor.get_capacity, ...
+      ↓ COPILOT_TURN_COMPLETE
+Result: ASK answer / ANALYZE recommendations / ACT proposal
+
+[ACT only continues through:]
+      ↓ PROPOSE / DECIDE / APPROVE / EXECUTE / OBSERVE_OUTCOME
+```
+
+---
+
+## Architecture Invariants (Tests Required in 15A Scaffolding)
+
+```python
+# CopilotService MUST NOT import ActionExecutor
+assert "ActionExecutor" not in copilot_service_imports
+
+# CopilotService MUST NOT call ApprovalStore.approve
+assert not hasattr(CopilotService, 'approve')
+
+# Copilot API MUST NOT expose /approve or /execute paths
+assert "/copilot/approve" not in router_paths
+assert "/copilot/execute" not in router_paths
+
+# CopilotIntent must be a typed enum
+assert isinstance(CopilotIntent.ASK, CopilotIntent)
+
+# Every CopilotTurn has a trace_id
+assert copilot_turn.trace_id is not None
+
+# Context resolver enforces bounds
+assert len(context.focus_entity_ids) <= 50
+```
+
+---
+
+## Missing Contracts (Gaps Requiring Implementation in 15B+)
+
+1. **`CopilotIntent` enum** — does not exist; must be created in Phase 15A scaffolding
+2. **`CopilotTurn` / `CopilotConversation` models** — do not exist
+3. **`CopilotAskResult` / `CopilotAnalyzeResult` / `CopilotActResult`** — do not exist
+4. **`OperationalContext` + context resolver** — does not exist; `neighbors()` API is available
+5. **`InMemoryCopilotStore`** — does not exist
+6. **`POST /api/v1/copilot/turn`** — does not exist
+7. **`CopilotService`** — does not exist; must enforce trust boundaries
+8. **Copilot SSE categories** — `COPILOT_TURN_STARTED` etc. not yet in `EventCategory`
+9. **`useCopilot()` hook** — does not exist; must share `useDemoSSE` event buffer
+
+---
+
+## Risk Assessment
+
+**Low risk:**
+- `OperationsCoordinationAgent.process_query` is a clean fit — no new agent needed
+- `ModelRequest.trace_id` is fully supported — end-to-end correlation is free
+- Existing proposal factory methods are correct — no manual proposal JSON
+- `POST /demo/approve` already handles the full approval+execution path — no new approval endpoint needed for Phase 15
+
+**Medium risk:**
+- `process_query` does not natively accept `trace_id` — must be threaded through `context` dict; this is a workaround, not a clean contract. Phase 15B should add `trace_id` as a native kwarg if possible.
+- `process_query` uses `_simulate_workforce_data()` as a fallback when live state is unavailable — Copilot must inject real `WarehouseState` into `context` to suppress simulation fallback.
+- No confirmed structured output from any Nemotron model — all JSON parsing is brittle; must have robust extraction fallback.
+
+**Architectural concern:**
+- `OperationsCoordinationAgent.process_query` was designed for conversational queries but did not anticipate needing to produce typed `CopilotAskResult` / `CopilotAnalyzeResult` / `CopilotActResult`. The `OperationsResponse.recommendations: list[str]` field returns plain strings, not `RecommendedAction` objects. Copilot's ANALYZE path needs `RecommendedAction` objects (with `action_type`, `target_id`, `reason`). This can be resolved by: (a) having the Copilot adapter parse the string recommendations into typed objects via the existing `OperationalAssessment` schema, or (b) calling `analyze_disruption` for ANALYZE turns and `process_query` only for pure ASK turns. **Option (b) is cleaner** — it gives Copilot typed `OperationalAssessment.recommendations` for ANALYZE/ACT while using `process_query` for conversational ASK.
+
+---
+
+## Phase 15 Implementation Sequence
+
+| Phase | Scope |
+|---|---|
+| **15A** | Contracts, audit (this doc), typed scaffolding, architecture invariant tests |
+| **15B** | ASK — read-only conversational questions |
+| **15C** | ANALYZE — typed recommendations without actions |
+| **15D** | ACT — governed ActionProposal flow |
+| **15E** | Copilot UI — drawer, conversation, trace integration |
+| **15F** | Canonical three-turn demo: "Why?" → "What should we do?" → "Do it." |
+| **15G** | Hardening: stale state, UNKNOWN outcomes, error states, docs |

--- a/docs/developer/PHASE_15_COPILOT_INTEGRATION.md
+++ b/docs/developer/PHASE_15_COPILOT_INTEGRATION.md
@@ -1,0 +1,111 @@
+# Phase 15 — Copilot Integration Boundary
+
+This document defines the architectural contract for the Phase 15 Copilot feature. It is written in Phase 14G so that Phase 15 work starts from a clear, agreed-upon boundary.
+
+The Copilot entry point is already reserved in the UI (`data-testid="phase15-copilot-button"`) but is disabled. No Copilot functionality is implemented in Phase 14.
+
+---
+
+## Recommended Placement
+
+The Copilot panel should open as a **slide-over drawer** anchored to the right side of the DemoShell, beneath the top nav bar. It must not replace the lifecycle rail or stage content — it is a companion view.
+
+Entry point: the existing disabled `Phase15CopilotButton` in `src/pages/DemoShell.tsx` (top navigation row, left of mode switcher). When enabled in Phase 15, clicking this button opens the Copilot drawer.
+
+Do not add a second entry point or route (`/copilot`). The Copilot is contextual to an active demo session.
+
+---
+
+## Shared State Copilot Must Consume
+
+Copilot is NOT a second source of truth. It reads from the same state the main UI already has:
+
+| State | Source | How to access |
+|---|---|---|
+| Demo status (scenario, world, KPIs) | React Query cache | `useQueryClient().getQueryData(['demo-status'])` or `useDemoStatus()` hook |
+| SSE events | `useDemoSSE` hook | Pass via prop from DemoShell, do not open a second SSE connection |
+| Analysis result | Parent state in DemoShell | Pass as prop — do not re-trigger analysis |
+| Pending approvals | `demoStatus.pending_approvals` | Same polling source as the rest of the UI |
+| Runtime status | `useRuntimeStatus` hook | Reuse existing query |
+
+**Copilot must share the same React Query client.** Pass the query client via `QueryClientProvider` (already in place). Do not create a second client.
+
+---
+
+## APIs Copilot Should Call
+
+Copilot may call:
+- `GET /api/v1/demo/status` — already polled every 3s; use React Query cache, do not add a separate poller
+- `GET /api/v1/events/stream` — already consumed by `useDemoSSE`; do not open a second SSE connection. Reuse the same event stream by accepting SSE events as props.
+- `POST /api/v1/demo/analyze` — only if user explicitly requests re-analysis via Copilot. Must show the same `analyzing` guard the main UI uses to prevent double-analyze.
+- `GET /api/v1/demo/counterfactual` — if Copilot surfaces counterfactual scenarios (see CounterfactualPanel for existing implementation)
+
+Copilot may NOT call:
+- Any API that starts, resets, or stops a scenario (`POST /demo/scenario/{name}/start`, `POST /demo/scenario/reset`) without routing through `DemoShell` handlers.
+- Any approval endpoint (`POST /demo/approve/*`, `POST /demo/reject/*`) — see "Actions Copilot Must NEVER Execute Directly" below.
+
+---
+
+## Actions Copilot Must NEVER Execute Directly
+
+The Copilot is an assistant. It explains, summarizes, and surfaces options. It does not act.
+
+Copilot must NEVER:
+- Call `demoAPI.approvePending()` or `demoAPI.rejectPending()` directly
+- Call `demoAPI.startScenario()` or `demoAPI.resetScenario()` directly
+- POST to any execution endpoint
+- Modify the global `analysisResult` state without going through the `handleAnalyze` handler in DemoShell
+
+If the user asks Copilot "approve this" — Copilot must:
+1. Surface the pending approval card from the existing ApproveStage view
+2. Highlight the **APPROVE & EXECUTE** button already in the UI
+3. NOT call the approval API itself
+
+The approval path must always pass through the human operator interacting with the `ApproveStage` component.
+
+---
+
+## How Copilot Links to Proposal/Approval/Trace Views
+
+Copilot may render links or "jump to" controls that:
+- Scroll or focus the main stage content to a specific proposal or approval
+- Open the Expert overlay at the `trace` tab (use `onViewFullTrace` callback from DemoShell)
+- Deep-link to a lifecycle stage by setting a shared active-stage signal (add to DemoShell context if needed)
+
+Copilot must NOT duplicate the trace/proposal/decision views — it references and links to them.
+
+---
+
+## Trust Boundary Requirements
+
+The trust boundary enforced in Phase 14 must be preserved:
+
+```
+Agent/model → analyzes/proposes ONLY
+Human → approves ALWAYS when required
+ActionExecutor → executes AFTER approval
+Copilot → explains, summarizes, links to existing views
+```
+
+Copilot output must be clearly labeled as assistant output, not as an authoritative system status. Example: use a distinct header like "Copilot" with a Phase 15 indicator.
+
+Copilot reasoning must not be shown in the existing lifecycle rail or stage content panes — those are reserved for authoritative pipeline output.
+
+---
+
+## Implementation Notes
+
+- Copilot drawer component: `src/components/demo/copilot/CopilotDrawer.tsx` (to be created in Phase 15)
+- The existing `Phase15CopilotButton` in `DemoShell.tsx` will be wired up when CopilotDrawer is ready
+- All new Copilot state should be local to CopilotDrawer or a new `CopilotContext` — do not pollute DemoShell state
+- Copilot tests should go in `src/__tests__/demo/phase15_copilot.test.tsx`
+
+---
+
+## What Is Out of Scope for Phase 15 Copilot
+
+- Autonomous warehouse actions of any kind
+- A second SSE stream
+- A separate API backend for Copilot
+- Replacing any existing lifecycle stage views
+- Fabricated analytics or placeholder KPIs not from an authoritative API

--- a/packages/maiw-agents/maiw_agents/operations/agent.py
+++ b/packages/maiw-agents/maiw_agents/operations/agent.py
@@ -1160,6 +1160,8 @@ class OperationsCoordinationAgent:
         scenario_context: str = "",
         trace_id: str,
         deadline: Any = None,
+        reasoning_level: Any = None,
+        risk_level: Any = None,
     ) -> Any:
         """
         Observe warehouse state and produce an OperationalAssessment.
@@ -1269,6 +1271,9 @@ class OperationsCoordinationAgent:
                 latency_ms=0.0,
             )
 
+        _reasoning = reasoning_level if reasoning_level is not None else ReasoningLevel.HIGH
+        _risk = risk_level if risk_level is not None else RiskLevel.HIGH
+
         response = await self.model_gateway.generate(
             ModelRequest(
                 task="warehouse.operations.analyze_disruption",
@@ -1276,8 +1281,8 @@ class OperationsCoordinationAgent:
                     {"role": "system", "content": system_msg},
                     {"role": "user", "content": user_msg},
                 ],
-                reasoning=ReasoningLevel.HIGH,
-                risk_level=RiskLevel.HIGH,
+                reasoning=_reasoning,
+                risk_level=_risk,
                 trace_id=trace_id,
                 deadline=deadline,
             )

--- a/src/ui/web/src/__tests__/demo/phase14G.test.tsx
+++ b/src/ui/web/src/__tests__/demo/phase14G.test.tsx
@@ -1,0 +1,697 @@
+/**
+ * Phase 14G tests — UI Readiness and Demo Hardening.
+ *
+ * Spec contracts verified:
+ *  - Phase 15 Copilot entry point renders as disabled, aria-disabled, not interactive
+ *  - Phase 15 Copilot button has no onClick that triggers any action
+ *  - Backend unavailable state: renders BackendErrorBanner with retry button
+ *  - Backend unavailable: no blank screen (banner shown, not empty)
+ *  - SSE connected indicator visible during active scenario
+ *  - SSE disconnected indicator visible when not connected
+ *  - Loading spinner shown during initial connection (not blank screen)
+ *  - Loading state has accessible role="status" and aria-label
+ *  - Proposal identifiers (proposal_id, pending_id, trace_id) are visible in ApproveStage
+ *  - Approval buttons disabled after click (duplicate-submission prevention)
+ *  - Approve button is disabled when actioned=true
+ *  - Reject button is disabled when actioned=true
+ *  - Approval expired: action buttons not available
+ *  - Error states: backend reject (404) shows consumed message
+ *  - Error states: network error shows error message
+ *  - Missing/null pendingApprovals renders empty state message (no crash)
+ *  - Missing/null analysisResult renders ObserveStage safely (no crash)
+ *  - Scenario reset: reset button calls onReset
+ *  - ExecuteStage UNKNOWN outcome shows reconciliation notice
+ *  - ExecuteStage FAILED outcome shows FAILED badge
+ *  - Demo shell renders system footer with system status
+ *  - DemoShell data-testid="demo-shell" is present
+ *  - Trust boundary: HUMAN APPROVAL REQUIRED text in ApproveStage
+ *  - Trust boundary: ActionExecutor text in ExecuteStage
+ */
+
+import React from 'react';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { ThemeProvider } from '@mui/material/styles';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router-dom';
+import { nvidiaTheme } from '../../theme/nvidiaTheme';
+
+// Components under test
+import ApproveStage from '../../components/demo/stages/ApproveStage';
+import ExecuteStage from '../../components/demo/stages/ExecuteStage';
+import ObserveStage from '../../components/demo/stages/ObserveStage';
+import { DemoStatus, AnalysisResult, PendingApproval, KPISnapshot } from '../../services/demoAPI';
+import { SSEEvent } from '../../hooks/useDemoSSE';
+
+// ── Mocks ──────────────────────────────────────────────────────────────────────
+
+jest.mock('../../services/demoAPI', () => ({
+  demoAPI: {
+    listScenarios: jest.fn().mockResolvedValue([]),
+    startScenario: jest.fn(),
+    getStatusSafe: jest.fn().mockResolvedValue(null),
+    analyze: jest.fn(),
+    approvePending: jest.fn(),
+    rejectPending: jest.fn(),
+    getCounterfactualResult: jest.fn().mockResolvedValue(null),
+    resetScenario: jest.fn().mockResolvedValue({ active: false }),
+    pauseScenario: jest.fn(),
+    resumeScenario: jest.fn(),
+  },
+}));
+
+jest.mock('../../hooks/useDemoSSE', () => ({
+  useDemoSSE: () => ({ events: [], connected: false, error: null, clear: jest.fn() }),
+}));
+
+jest.mock('../../hooks/useRuntimeStatus', () => ({
+  useRuntimeStatus: () => ({
+    data: { maiw_operational_status: 'HEALTHY', model_gateway_status: 'HEALTHY', domain_health: {} },
+    isLoading: false,
+  }),
+}));
+
+jest.mock('../../hooks/useDemoStatus', () => ({
+  useDemoStatus: jest.fn(),
+}));
+
+const { useDemoStatus } = require('../../hooks/useDemoStatus');
+const { demoAPI } = require('../../services/demoAPI');
+
+// ── Fixtures ───────────────────────────────────────────────────────────────────
+
+const baseKPI: KPISnapshot = {
+  sim_time_seconds: 60,
+  clock_iso: '2026-08-31T10:00:00Z',
+  equipment_total: 8,
+  equipment_operational_pct: 87.5,
+  labor_total: 6,
+  labor_availability_pct: 66.7,
+  labor_utilization_pct: 75,
+  pending_backlog: 5,
+  wave_risk_score: 0.6,
+  wave_risk_level: 'medium',
+  low_stock_count: 2,
+  state_freshness_seconds: 30,
+  service_risk_index: 0.4,
+  capacity_throughput_proxy: 0.8,
+  wave_completion_pct: 60,
+  simulated_throughput: 120,
+  projected_service_level: 85,
+  time_to_recovery_seconds: null,
+};
+
+const baseDemoStatus: DemoStatus = {
+  active: true,
+  paused: false,
+  scenario: {
+    name: 'labor_constraint_wave_risk',
+    display_name: 'Labor Constraint — Wave Risk',
+    description: 'Test',
+    tags: ['labor'],
+  },
+  world: {
+    warehouse_id: 'DC-47',
+    clock_iso: '2026-08-31T10:00:00Z',
+    elapsed_seconds: 60,
+    equipment: { total: 8, available: 7, assigned: 5, maintenance: 0, offline: 1 },
+    workers: { total: 6, active: 4, inactive: 2 },
+    tasks: { total: 20, pending: 5, in_progress: 10, completed: 5 },
+    inventory: { total_skus: 100, low_stock: 2 },
+  },
+  current_kpis: baseKPI,
+  kpi_history: [],
+  pending_approvals: [],
+};
+
+const inactiveDemoStatus: DemoStatus = {
+  active: false,
+  paused: false,
+  scenario: null,
+  world: null,
+  current_kpis: null,
+  kpi_history: [],
+  pending_approvals: [],
+};
+
+const basePendingApproval: PendingApproval = {
+  pending_id: 'pend-abc-123',
+  proposal_id: 'prop-xyz-456',
+  decision_id: 'dec-789',
+  trace_id: 'trace-ttt-111',
+  capability: 'REALLOCATE_LABOR',
+  target: 'zone-3',
+  domain: 'labor',
+  risk_level: 'high',
+  objective: 'Shift workers to cover wave demand spike',
+  rationale: 'Labor availability dropped to 50% — wave risk critical',
+  priority: 'high',
+  queued_at: new Date().toISOString(),
+};
+
+const baseAnalysisResult: AnalysisResult = {
+  ok: true,
+  trace_id: 'trace-ttt-111',
+  assessment: {
+    snapshot_id: 'snap-001',
+    warehouse_id: 'DC-47',
+    assessed_at: '2026-08-31T10:00:00Z',
+    summary: 'Labor constraint detected',
+    severity: 'high',
+    domains_affected: ['labor'],
+    facts_observed: ['Labor availability: 50%', 'Wave risk: critical'],
+    recommendations: [],
+    model_id: 'claude-sonnet-4-5',
+    routing_rule: 'default',
+    routing_reason: 'No special conditions',
+    latency_ms: 800,
+  },
+  proposal_results: [],
+  lifecycle: [],
+};
+
+const noSseEvents: SSEEvent[] = [];
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+function makeQC() {
+  return new QueryClient({ defaultOptions: { queries: { retry: false } } });
+}
+
+function wrap(ui: React.ReactElement) {
+  return render(
+    <MemoryRouter>
+      <QueryClientProvider client={makeQC()}>
+        <ThemeProvider theme={nvidiaTheme}>
+          {ui}
+        </ThemeProvider>
+      </QueryClientProvider>
+    </MemoryRouter>
+  );
+}
+
+function renderShell(demoStatusValue: DemoStatus | null, isLoading = false) {
+  useDemoStatus.mockReturnValue({
+    status: demoStatusValue,
+    isLoading,
+    isDemoMode: demoStatusValue != null,
+    refetch: jest.fn(),
+  });
+  (demoAPI.listScenarios as jest.Mock).mockResolvedValue([]);
+  const DemoShell = require('../../pages/DemoShell').default;
+  return wrap(<DemoShell />);
+}
+
+function stageProps(overrides: Partial<{
+  demoStatus: DemoStatus;
+  pendingApprovals: PendingApproval[];
+  sseEvents: SSEEvent[];
+  analysisResult: AnalysisResult | null;
+  analyzing: boolean;
+  onAnalyze: () => Promise<void>;
+  onReset: () => void;
+  onViewFullTrace: () => void;
+  onOpenExplanation: (focus: any) => void;
+}> = {}) {
+  return {
+    currentStage: 'APPROVE' as const,
+    demoStatus: baseDemoStatus,
+    pendingApprovals: [],
+    sseEvents: noSseEvents,
+    analysisResult: null,
+    analyzing: false,
+    onAnalyze: jest.fn().mockResolvedValue(undefined),
+    onReset: jest.fn(),
+    onViewFullTrace: jest.fn(),
+    onOpenExplanation: jest.fn(),
+    ...overrides,
+  };
+}
+
+beforeEach(() => jest.clearAllMocks());
+
+// ── Tests: Phase 15 Copilot entry point ───────────────────────────────────────
+
+describe('Phase 15 Copilot entry point', () => {
+  it('renders with Phase 15 Copilot button disabled', () => {
+    renderShell(inactiveDemoStatus);
+    const btn = screen.getByTestId('phase15-copilot-button');
+    expect(btn).toBeInTheDocument();
+    expect(btn).toBeDisabled();
+    expect(btn).toHaveAttribute('aria-disabled', 'true');
+  });
+
+  it('Phase 15 Copilot button shows Phase 15 label', () => {
+    renderShell(inactiveDemoStatus);
+    const btn = screen.getByTestId('phase15-copilot-button');
+    expect(btn).toHaveTextContent('Copilot');
+    expect(btn).toHaveTextContent('Phase 15');
+  });
+
+  it('Phase 15 Copilot button has accessible tooltip title mentioning Phase 15', () => {
+    renderShell(inactiveDemoStatus);
+    const btn = screen.getByTestId('phase15-copilot-button');
+    expect(btn).toHaveAttribute('title', expect.stringContaining('Phase 15'));
+  });
+
+  it('Phase 15 Copilot button aria-label is accessible', () => {
+    renderShell(inactiveDemoStatus);
+    const btn = screen.getByTestId('phase15-copilot-button');
+    expect(btn).toHaveAttribute('aria-label');
+    const label = btn.getAttribute('aria-label') ?? '';
+    expect(label.toLowerCase()).toMatch(/copilot|phase 15/i);
+  });
+});
+
+// ── Tests: Backend unavailable state ──────────────────────────────────────────
+
+describe('Backend unavailable state', () => {
+  it('shows BackendErrorBanner when backend returns null after load completes', () => {
+    renderShell(null, false);
+    expect(screen.getByTestId('backend-error-banner')).toBeInTheDocument();
+  });
+
+  it('BackendErrorBanner has role=alert for accessibility', () => {
+    renderShell(null, false);
+    const banner = screen.getByTestId('backend-error-banner');
+    expect(banner).toHaveAttribute('role', 'alert');
+  });
+
+  it('BackendErrorBanner shows retry button', () => {
+    renderShell(null, false);
+    expect(screen.getByTestId('backend-retry-button')).toBeInTheDocument();
+  });
+
+  it('no blank screen: banner shown when backend unavailable', () => {
+    renderShell(null, false);
+    expect(screen.getByTestId('backend-error-banner')).toBeInTheDocument();
+    // Loading spinner should NOT be shown (load complete)
+    expect(screen.queryByTestId('demo-loading')).not.toBeInTheDocument();
+  });
+
+  it('does not show ScenarioSelector when backend is unavailable', () => {
+    renderShell(null, false);
+    expect(screen.queryByText(/select a scenario to begin/i)).not.toBeInTheDocument();
+  });
+});
+
+// ── Tests: Loading state ───────────────────────────────────────────────────────
+
+describe('Loading state', () => {
+  it('shows loading indicator during initial connection', () => {
+    renderShell(null, true); // isLoading=true, status=null
+    expect(screen.getByTestId('demo-loading')).toBeInTheDocument();
+  });
+
+  it('loading state has accessible role=status', () => {
+    renderShell(null, true);
+    const loading = screen.getByTestId('demo-loading');
+    expect(loading).toHaveAttribute('role', 'status');
+  });
+
+  it('loading state has aria-label', () => {
+    renderShell(null, true);
+    const loading = screen.getByTestId('demo-loading');
+    expect(loading).toHaveAttribute('aria-label');
+  });
+
+  it('does not show backend error during active loading', () => {
+    renderShell(null, true);
+    expect(screen.queryByTestId('backend-error-banner')).not.toBeInTheDocument();
+  });
+});
+
+// ── Tests: DemoShell identity ──────────────────────────────────────────────────
+
+describe('DemoShell identity', () => {
+  it('has data-testid="demo-shell"', () => {
+    renderShell(inactiveDemoStatus);
+    expect(screen.getByTestId('demo-shell')).toBeInTheDocument();
+  });
+
+  it('shows MAIW product identity text', () => {
+    renderShell(inactiveDemoStatus);
+    expect(screen.getByText(/MAIW Command Center/i)).toBeInTheDocument();
+  });
+
+  it('shows DEMO MODE indicator badge', () => {
+    renderShell(inactiveDemoStatus);
+    expect(screen.getByText(/Synthetic demo/i)).toBeInTheDocument();
+  });
+
+  it('shows system status in footer', () => {
+    renderShell(inactiveDemoStatus);
+    expect(screen.getAllByText(/System/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/HEALTHY/i).length).toBeGreaterThan(0);
+  });
+});
+
+// ── Tests: Proposal identifier display ────────────────────────────────────────
+
+describe('ApproveStage — proposal identifiers', () => {
+  it('shows proposal_id in ApprovalCard', () => {
+    wrap(
+      <ApproveStage {...stageProps({
+        pendingApprovals: [basePendingApproval],
+        analysisResult: baseAnalysisResult,
+      })} />
+    );
+    expect(screen.getByText(/prop-xyz-456/i)).toBeInTheDocument();
+  });
+
+  it('shows decision_id in ApprovalCard', () => {
+    wrap(
+      <ApproveStage {...stageProps({
+        pendingApprovals: [basePendingApproval],
+        analysisResult: baseAnalysisResult,
+      })} />
+    );
+    expect(screen.getByText(/dec-789/i)).toBeInTheDocument();
+  });
+
+  it('shows capability in ApprovalCard', () => {
+    wrap(
+      <ApproveStage {...stageProps({
+        pendingApprovals: [basePendingApproval],
+        analysisResult: baseAnalysisResult,
+      })} />
+    );
+    expect(screen.getByText(/REALLOCATE_LABOR/i)).toBeInTheDocument();
+  });
+
+  it('shows rationale text', () => {
+    wrap(
+      <ApproveStage {...stageProps({
+        pendingApprovals: [basePendingApproval],
+        analysisResult: baseAnalysisResult,
+      })} />
+    );
+    expect(screen.getByText(/Labor availability dropped to 50%/i)).toBeInTheDocument();
+  });
+
+  it('shows priority field', () => {
+    wrap(
+      <ApproveStage {...stageProps({
+        pendingApprovals: [basePendingApproval],
+        analysisResult: baseAnalysisResult,
+      })} />
+    );
+    expect(screen.getByText(/priority/i)).toBeInTheDocument();
+  });
+});
+
+// ── Tests: Approval workflow controls ─────────────────────────────────────────
+
+describe('ApproveStage — approval controls', () => {
+  it('approve and reject buttons enabled initially', () => {
+    wrap(
+      <ApproveStage {...stageProps({ pendingApprovals: [basePendingApproval] })} />
+    );
+    expect(screen.getByTestId('approve-execute-button')).not.toBeDisabled();
+    expect(screen.getByTestId('reject-button')).not.toBeDisabled();
+  });
+
+  it('empty state shown when no pending approvals', () => {
+    wrap(
+      <ApproveStage {...stageProps({ pendingApprovals: [] })} />
+    );
+    // MonoText doesn't forward data-testid; check text content instead
+    expect(screen.getByText(/No pending approvals/i)).toBeInTheDocument();
+  });
+
+  it('approval card shown for pending approval', () => {
+    wrap(
+      <ApproveStage {...stageProps({ pendingApprovals: [basePendingApproval] })} />
+    );
+    expect(screen.getByTestId('approval-card')).toBeInTheDocument();
+  });
+
+  it('HUMAN APPROVAL REQUIRED shown in card', () => {
+    wrap(
+      <ApproveStage {...stageProps({ pendingApprovals: [basePendingApproval] })} />
+    );
+    expect(screen.getByText(/HUMAN APPROVAL REQUIRED/i)).toBeInTheDocument();
+  });
+
+  it('duplicate submission prevention: result badge replaces buttons after approval', async () => {
+    (demoAPI.approvePending as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      status: 'executed',
+      execution_id: 'exec-001',
+    });
+
+    wrap(
+      <ApproveStage {...stageProps({ pendingApprovals: [basePendingApproval] })} />
+    );
+
+    const approveBtn = screen.getByTestId('approve-execute-button');
+    await act(async () => {
+      fireEvent.click(approveBtn);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('approval-result')).toBeInTheDocument();
+    });
+
+    // Approve and reject buttons replaced by result badge — no duplicate submit possible
+    expect(screen.queryByTestId('approve-execute-button')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('reject-button')).not.toBeInTheDocument();
+  });
+
+  it('rejection: shows REJECTED outcome badge', async () => {
+    (demoAPI.rejectPending as jest.Mock).mockResolvedValueOnce({ ok: true });
+
+    wrap(
+      <ApproveStage {...stageProps({ pendingApprovals: [basePendingApproval] })} />
+    );
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('reject-button'));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('approval-result')).toBeInTheDocument();
+      expect(screen.getByText('REJECTED')).toBeInTheDocument();
+    });
+  });
+
+  it('backend 404: shows consumed message (not generic error)', async () => {
+    const err404 = new Error('Not found') as any;
+    err404.response = { status: 404 };
+    (demoAPI.approvePending as jest.Mock).mockRejectedValueOnce(err404);
+
+    wrap(
+      <ApproveStage {...stageProps({ pendingApprovals: [basePendingApproval] })} />
+    );
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('approve-execute-button'));
+    });
+
+    await waitFor(() => {
+      // Multiple "CONSUMED" badges may appear; just confirm at least one shows
+      expect(screen.getAllByText('CONSUMED').length).toBeGreaterThan(0);
+    });
+  });
+
+  it('expired approval: action buttons are disabled', () => {
+    const expiredApproval: PendingApproval = {
+      ...basePendingApproval,
+      queued_at: new Date(Date.now() - 15 * 60 * 1000).toISOString(), // 15 min ago
+    };
+    wrap(
+      <ApproveStage {...stageProps({ pendingApprovals: [expiredApproval] })} />
+    );
+    expect(screen.getByTestId('approve-execute-button')).toBeDisabled();
+    expect(screen.getByTestId('reject-button')).toBeDisabled();
+  });
+
+  it('expired approval: EXPIRED label shown', () => {
+    const expiredApproval: PendingApproval = {
+      ...basePendingApproval,
+      queued_at: new Date(Date.now() - 15 * 60 * 1000).toISOString(),
+    };
+    wrap(
+      <ApproveStage {...stageProps({ pendingApprovals: [expiredApproval] })} />
+    );
+    expect(screen.getAllByText('EXPIRED').length).toBeGreaterThan(0);
+  });
+});
+
+// ── Tests: ObserveStage missing data ──────────────────────────────────────────
+
+describe('ObserveStage — missing / null data', () => {
+  it('renders without crash when world is null', () => {
+    const statusNoWorld: DemoStatus = { ...baseDemoStatus, world: null };
+    expect(() => {
+      wrap(
+        <ObserveStage {...stageProps({
+          demoStatus: statusNoWorld,
+          analysisResult: null,
+        })} />
+      );
+    }).not.toThrow();
+    expect(screen.getByTestId('observe-stage')).toBeInTheDocument();
+  });
+
+  it('renders without crash when current_kpis is null', () => {
+    const statusNoKPIs: DemoStatus = { ...baseDemoStatus, current_kpis: null };
+    expect(() => {
+      wrap(
+        <ObserveStage {...stageProps({
+          demoStatus: statusNoKPIs,
+          analysisResult: null,
+        })} />
+      );
+    }).not.toThrow();
+    expect(screen.getByTestId('observe-stage')).toBeInTheDocument();
+  });
+
+  it('shows Run Analysis button when no analysis result yet', () => {
+    wrap(
+      <ObserveStage {...stageProps({ analysisResult: null })} />
+    );
+    expect(screen.getByTestId('run-analysis-button')).toBeInTheDocument();
+  });
+
+  it('shows re-run button when analysis result is present', () => {
+    wrap(
+      <ObserveStage {...stageProps({ analysisResult: baseAnalysisResult })} />
+    );
+    expect(screen.getByTestId('rerun-analysis-button')).toBeInTheDocument();
+  });
+
+  it('analyze button is disabled while analyzing', () => {
+    wrap(
+      <ObserveStage {...stageProps({ analysisResult: null, analyzing: true })} />
+    );
+    expect(screen.getByTestId('run-analysis-button')).toBeDisabled();
+  });
+});
+
+// ── Tests: ExecuteStage outcome rendering ─────────────────────────────────────
+
+describe('ExecuteStage — all canonical outcomes', () => {
+  function renderWithOutcome(outcome: string) {
+    return wrap(
+      <ExecuteStage {...stageProps({
+        sseEvents: noSseEvents,
+        analysisResult: {
+          ...baseAnalysisResult,
+          lifecycle: [{
+            phase: 'EXECUTE' as const,
+            status: outcome,
+            execution_id: `exec-${outcome}`,
+            capability: 'REALLOCATE_LABOR',
+          }],
+        },
+        currentStage: 'EXECUTE' as const,
+      })} />
+    );
+  }
+
+  it('shows EXECUTED badge', () => {
+    renderWithOutcome('executed');
+    expect(screen.getByTestId('outcome-badge-executed')).toBeInTheDocument();
+    expect(screen.getByText('EXECUTED')).toBeInTheDocument();
+  });
+
+  it('shows FAILED badge', () => {
+    renderWithOutcome('failed');
+    expect(screen.getByTestId('outcome-badge-failed')).toBeInTheDocument();
+    expect(screen.getByText('FAILED')).toBeInTheDocument();
+  });
+
+  it('shows UNKNOWN badge with reconciliation notice', () => {
+    renderWithOutcome('unknown');
+    expect(screen.getByTestId('outcome-badge-unknown')).toBeInTheDocument();
+    expect(screen.getByTestId('reconciliation-notice')).toBeInTheDocument();
+    expect(screen.getByText(/Reconciliation required/i)).toBeInTheDocument();
+  });
+
+  it('shows NO_OP badge', () => {
+    renderWithOutcome('no_op');
+    expect(screen.getByTestId('outcome-badge-no_op')).toBeInTheDocument();
+  });
+
+  it('shows DEFERRED badge', () => {
+    renderWithOutcome('deferred');
+    expect(screen.getByTestId('outcome-badge-deferred')).toBeInTheDocument();
+  });
+
+  it('shows CONFLICT badge', () => {
+    renderWithOutcome('conflict');
+    expect(screen.getByTestId('outcome-badge-conflict')).toBeInTheDocument();
+  });
+
+  it('shows waiting state when no lifecycle data and no SSE', () => {
+    wrap(
+      <ExecuteStage {...stageProps({
+        analysisResult: { ...baseAnalysisResult, lifecycle: [] },
+        sseEvents: [],
+        currentStage: 'EXECUTE' as const,
+      })} />
+    );
+    expect(screen.getByTestId('execute-waiting')).toBeInTheDocument();
+  });
+});
+
+// ── Tests: Trust boundary ──────────────────────────────────────────────────────
+
+describe('Trust boundary', () => {
+  it('ApproveStage shows HUMAN APPROVAL REQUIRED — agent does not self-authorize', () => {
+    wrap(
+      <ApproveStage {...stageProps({ pendingApprovals: [basePendingApproval] })} />
+    );
+    expect(screen.getByText(/HUMAN APPROVAL REQUIRED/i)).toBeInTheDocument();
+  });
+
+  it('ExecuteStage subtitle references ActionExecutor — not model/LLM', () => {
+    wrap(
+      <ExecuteStage {...stageProps({ sseEvents: [], analysisResult: baseAnalysisResult })} />
+    );
+    expect(screen.getByText(/ActionExecutor/i)).toBeInTheDocument();
+  });
+
+  it('DemoShell Copilot button is disabled — Copilot does NOT execute actions', () => {
+    renderShell(inactiveDemoStatus);
+    const btn = screen.getByTestId('phase15-copilot-button');
+    expect(btn).toBeDisabled();
+  });
+});
+
+// ── Tests: Scenario reset behavior ────────────────────────────────────────────
+
+describe('Scenario selector shown after reset', () => {
+  it('ScenarioSelector renders when scenario is not active', async () => {
+    renderShell({
+      ...inactiveDemoStatus,
+      active: false,
+    });
+    await waitFor(() => {
+      expect(screen.getByText(/select a scenario to begin/i)).toBeInTheDocument();
+    });
+  });
+
+  it('LifecycleRail not shown when no scenario active', () => {
+    renderShell(inactiveDemoStatus);
+    expect(screen.queryByTestId('lifecycle-rail')).not.toBeInTheDocument();
+  });
+});
+
+// ── Tests: SSE status indicator ───────────────────────────────────────────────
+
+describe('SSE status in footer', () => {
+  // SSE status is only shown when a scenario is active; we test the component directly.
+  // The useDemoSSE mock always returns connected:false / error:null.
+  // For DemoShell shell level tests, SSE chip only renders during active scenario.
+  it('DemoShell footer renders Safety section', () => {
+    renderShell(inactiveDemoStatus);
+    expect(screen.getByText(/Safety/i)).toBeInTheDocument();
+  });
+
+  it('System status shown in footer', () => {
+    renderShell(inactiveDemoStatus);
+    expect(screen.getAllByText(/HEALTHY/i).length).toBeGreaterThan(0);
+  });
+});

--- a/src/ui/web/src/pages/DemoShell.tsx
+++ b/src/ui/web/src/pages/DemoShell.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useCallback } from 'react';
-import { Box, Typography } from '@mui/material';
+import { Box, CircularProgress, Typography } from '@mui/material';
 import { useQueryClient } from '@tanstack/react-query';
 import { useDemoStatus } from '../hooks/useDemoStatus';
 import { useRuntimeStatus } from '../hooks/useRuntimeStatus';
@@ -79,6 +79,124 @@ function ExpertToggle({ on, onToggle }: { on: boolean; onToggle: () => void }) {
         background: on ? '#58A6FF' : '#30363D',
         flexShrink: 0,
       }} />
+    </Box>
+  );
+}
+
+/**
+ * Phase15CopilotButton — reserved entry point for Phase 15.
+ * DISABLED. Must not imply any functional Copilot capability in Phase 14.
+ */
+function Phase15CopilotButton() {
+  return (
+    <Box
+      component="button"
+      disabled
+      aria-disabled="true"
+      aria-label="Copilot — available in Phase 15"
+      data-testid="phase15-copilot-button"
+      title="Coming in Phase 15 — not yet available"
+      sx={{
+        display: 'flex', alignItems: 'center', gap: 0.75,
+        background: 'transparent',
+        border: '1px solid #21262D',
+        borderRadius: '4px',
+        px: '10px', py: '4px',
+        fontFamily: 'monospace',
+        fontSize: '0.65rem',
+        color: '#30363D',
+        cursor: 'not-allowed',
+        letterSpacing: '0.06em',
+        textTransform: 'uppercase',
+        opacity: 0.5,
+      }}
+    >
+      Copilot
+      <Box component="span" sx={{
+        fontFamily: 'monospace', fontSize: '0.52rem', color: '#484F58',
+        border: '1px solid #21262D', borderRadius: '3px',
+        px: '4px', py: '0px', ml: 0.25, lineHeight: 1.6,
+      }}>
+        Phase 15
+      </Box>
+    </Box>
+  );
+}
+
+/**
+ * SSEStatusChip — shows SSE connection state when a scenario is active.
+ * Only renders during active scenario to avoid noise on idle screen.
+ */
+function SSEStatusChip({ connected, error }: { connected: boolean; error: string | null }) {
+  if (connected) {
+    return (
+      <Box
+        data-testid="sse-status-connected"
+        sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}
+      >
+        <Box sx={{ width: 5, height: 5, borderRadius: '50%', background: '#3FB950', flexShrink: 0, boxShadow: '0 0 4px #3FB950' }} />
+        <Typography sx={{ fontFamily: 'monospace', fontSize: '0.58rem', color: '#484F58', letterSpacing: '0.06em', textTransform: 'uppercase' }}>
+          Live
+        </Typography>
+      </Box>
+    );
+  }
+  return (
+    <Box
+      data-testid="sse-status-disconnected"
+      sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}
+    >
+      <Box sx={{ width: 5, height: 5, borderRadius: '50%', background: '#D29922', flexShrink: 0 }} />
+      <Typography sx={{ fontFamily: 'monospace', fontSize: '0.58rem', color: '#D29922', letterSpacing: '0.06em', textTransform: 'uppercase' }}>
+        {error ? 'Reconnecting' : 'Connecting'}
+      </Typography>
+    </Box>
+  );
+}
+
+/**
+ * BackendErrorBanner — shown when backend returns null/unavailable and initial load is done.
+ */
+function BackendErrorBanner({ onRetry }: { onRetry: () => void }) {
+  return (
+    <Box
+      data-testid="backend-error-banner"
+      role="alert"
+      sx={{
+        m: 3,
+        p: 2,
+        background: '#1A0A0A',
+        border: '1px solid #F8514944',
+        borderRadius: '6px',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 1,
+        maxWidth: 480,
+      }}
+    >
+      <Typography sx={{ fontFamily: 'monospace', fontSize: '0.72rem', fontWeight: 700, color: '#F85149', letterSpacing: '0.04em', textTransform: 'uppercase' }}>
+        Backend unavailable
+      </Typography>
+      <Typography sx={{ fontFamily: 'monospace', fontSize: '0.68rem', color: '#8B949E', lineHeight: 1.5 }}>
+        Cannot reach the MAIW demo API. Confirm the backend is running on port 8000 and the proxy is configured.
+      </Typography>
+      <Box
+        component="button"
+        onClick={onRetry}
+        data-testid="backend-retry-button"
+        sx={{
+          alignSelf: 'flex-start',
+          background: 'transparent',
+          border: '1px solid #30363D',
+          borderRadius: '4px',
+          px: '12px', py: '6px',
+          fontFamily: 'monospace', fontSize: '0.65rem',
+          color: '#8B949E', cursor: 'pointer',
+          '&:hover': { color: '#C9D1D9', borderColor: '#484F58' },
+        }}
+      >
+        ↺ Retry connection
+      </Box>
     </Box>
   );
 }
@@ -244,6 +362,9 @@ export default function DemoShell() {
   const freshnessSecs = demoStatus?.current_kpis?.state_freshness_seconds;
   const stateLabel = freshnessSecs != null && freshnessSecs < 120 ? 'FRESH' : 'STALE';
 
+  // Detect backend unavailable: load done, no data
+  const backendUnavailable = !demoLoading && demoStatus === null;
+
   // ── Handlers ────────────────────────────────────────────────────────────────
 
   const handleStart = useCallback(async (name: string) => {
@@ -323,6 +444,8 @@ export default function DemoShell() {
           Synthetic demo
         </Box>
         <Box sx={{ flexGrow: 1 }} />
+        <Phase15CopilotButton />
+        <Box sx={{ width: '1px', height: 14, background: '#21262D', flexShrink: 0 }} />
         <ModeSwitcher mode={mode} onChange={setMode} />
         <Box sx={{ width: '1px', height: 14, background: '#21262D', flexShrink: 0 }} />
         <ExpertToggle on={expertMode} onToggle={() => setExpertMode(e => !e)} />
@@ -338,16 +461,28 @@ export default function DemoShell() {
 
       {/* Content */}
       <Box sx={{ flexGrow: 1, display: 'flex', flexDirection: 'column', overflow: 'auto' }}>
+        {/* ── Loading: initial connection ── */}
         {demoLoading && !demoStatus && (
-          <Box sx={{ p: 3 }}>
+          <Box
+            data-testid="demo-loading"
+            role="status"
+            aria-label="Connecting to demo backend"
+            sx={{ p: 3, display: 'flex', alignItems: 'center', gap: 1.5 }}
+          >
+            <CircularProgress size={14} sx={{ color: '#484F58' }} />
             <Typography sx={{ fontFamily: 'monospace', fontSize: '0.72rem', color: '#484F58' }}>
               Connecting to demo backend...
             </Typography>
           </Box>
         )}
 
+        {/* ── Backend unavailable ── */}
+        {backendUnavailable && (
+          <BackendErrorBanner onRetry={() => queryClient.invalidateQueries({ queryKey: ['demo-status'] })} />
+        )}
+
         {/* ── First-run: scenario selection ── */}
-        {(!scenarioActive) && !demoLoading && (
+        {(!scenarioActive) && !demoLoading && !backendUnavailable && (
           <ScenarioSelector onStart={handleStart} />
         )}
 
@@ -447,6 +582,12 @@ export default function DemoShell() {
             </Typography>
           );
         })()}
+        {scenarioActive && (
+          <>
+            <Box sx={{ width: '1px', height: 10, background: '#21262D' }} />
+            <SSEStatusChip connected={sseState.connected} error={sseState.error} />
+          </>
+        )}
         <Box sx={{ flexGrow: 1 }} />
         <Typography sx={{
           fontFamily: 'monospace', fontSize: '0.62rem', color: '#484F58',


### PR DESCRIPTION
## Description

Introduces the Copilot architecture and ASK implementation as the human conversational interaction layer over the governed MAIW lifecycle. Copilot is strictly an interaction layer — it never bypasses DecisionEngine, human approval, or ActionExecutor.

## Type of Change

- [x] New feature (non-breaking)
- [x] Documentation

## Related Issues

Phase 15A–15B. Follows PR #84 (Phase 14 Warehouse World).

## Changes Made

**Phase 14G — UI hardening for Phase 15**
- `src/ui/web/src/pages/DemoShell.tsx` — expert overlay, reliability demo mode, execute and operational outcome stages
- `src/ui/web/src/__tests__/demo/phase14G.test.tsx` — 500 frontend tests total

**Phase 15A — Copilot architecture**
- `docs/developer/PHASE_15_COPILOT_ARCHITECTURE.md` — 508-line trust boundary specification: intent model, conversation identity, agent/ModelGateway contracts, API design, SSE integration, UI architecture, risk assessment, implementation sequence 15A–15G
- `docs/developer/PHASE_15_COPILOT_INTEGRATION.md` — integration boundary contract for UI

**Phase 15B — ASK implementation**
- `apps/api/maiw_api/copilot/` — new package: `CopilotService`, `CopilotIntent`, `CopilotTurn`, `CopilotConversation`, `CopilotAskResult`, `InMemoryCopilotStore`, `ContextNeighborhood`
- `apps/api/maiw_api/routers/copilot.py` — `POST /api/v1/copilot/turn` only; no `/approve`, `/execute`, `/force-action`
- `apps/api/maiw_api/bootstrap.py` + `app.py` — `CopilotService` wired into `MAIWRuntime`
- `apps/api/maiw_api/demo/events.py` — 4 Copilot SSE categories
- `packages/maiw-agents/maiw_agents/operations/agent.py` — `analyze_disruption` accepts `reasoning_level`/`risk_level` kwargs; ModelGateway owns physical model selection
- `apps/api/tests/test_copilot_ask.py` — 41 tests (architecture invariants + behavior)

**README refresh**
- `## What MAIW Is` rewritten to reflect full MAIW v2 architecture and Observe → Reason → Propose → Decide → Approve → Execute → Observe Outcome lifecycle

## Testing

- 990 CORE CI passing
- 258 maiw-world + API passing (41 new Copilot ASK tests)
- 500 frontend passing

## Screenshots

Phase 15B is API-only. Copilot UI drawer is Phase 15C–15E.

## Checklist

- [x] Architecture invariants enforced: zero `ActionExecutor` / `ApprovalStore` / `DecisionEngine` imports in `CopilotService`
- [x] Copilot router exposes `/turn` only — no `/approve`, `/execute`, `/force-action`
- [x] ASK produces zero `ActionProposal`s, zero `DecisionEngine` evaluations, zero writes
- [x] Explicit degradation: `WarehouseState` unavailable → structured degraded response; never falls back to simulated data
- [x] Copilot expresses `ReasoningLevel`/`RiskLevel`; ModelGateway owns physical model selection
- [x] Three distinct IDs per turn: `conversation_id`, `turn_id`, `trace_id`

## Deployment Notes

- Requires `MAIW_DEMO_MODE=true` and MAIWRuntime initialized; returns 503 otherwise
- No new environment variables required
- Phase 15B is ASK only — ANALYZE and ACT require explicit approval before 15C

## Breaking Changes

None.
