### PR TITLE
Fix/phase 15b answerability

### DIFF
--- a/apps/api/maiw_api/copilot/models.py
+++ b/apps/api/maiw_api/copilot/models.py
@@ -90,6 +90,7 @@ class CopilotAskResult:
     degradation_reason: str | None = None
     answerability: str = "answerable"          # "answerable" | "insufficient_evidence" | "partial"
     missing_context: list[str] = field(default_factory=list)  # e.g. ["wave_state", "labor_state"]
+    timing: dict[str, float] = field(default_factory=dict)   # state_assembly_ms, graph_lookup_ms, model_inference_ms, total_ms
 
 
 # ── Turn / Conversation store models ─────────────────────────────────────────
@@ -176,6 +177,7 @@ class CopilotTurnResponse(BaseModel):
     degradation_reason: str | None = None
     answerability: str = "answerable"   # "answerable" | "insufficient_evidence" | "partial"
     missing_context: list[str] = Field(default_factory=list)
+    timing: dict = Field(default_factory=dict)  # state_assembly_ms, graph_lookup_ms, model_inference_ms, total_ms
 
     # Future: ANALYZE and ACT fields populated in 15C / 15D
     related_artifacts: dict = Field(default_factory=dict)

--- a/apps/api/maiw_api/copilot/models.py
+++ b/apps/api/maiw_api/copilot/models.py
@@ -60,12 +60,24 @@ class CopilotAskResult:
 
     MUST contain zero ActionProposals, zero DecisionEngine evaluations,
     zero writes. These are enforced by architecture invariant tests.
+
+    Answerability
+    -------------
+    answerability = "answerable"           — state present, answer grounded
+    answerability = "insufficient_evidence" — state absent or all-zero; refused
+    answerability = "partial"              — some domains missing; answer may be incomplete
+
+    skills_used vs skills_available
+    --------------------------------
+    skills_used       — capabilities actually invoked during this turn (empty for ASK)
+    skills_available  — capabilities the agent reported as reachable
     """
     answer: str
     evidence: list[EvidenceFact]
     neighborhood: ContextNeighborhood
     agent: str
-    skills_used: list[str]
+    skills_used: list[str]           # actually invoked — always [] for ASK
+    skills_available: list[str]      # agent-reported reachable capabilities
     model_id: str
     reasoning_level: str
     routing_rule: str
@@ -76,6 +88,8 @@ class CopilotAskResult:
     latency_ms: float
     degraded: bool = False
     degradation_reason: str | None = None
+    answerability: str = "answerable"          # "answerable" | "insufficient_evidence" | "partial"
+    missing_context: list[str] = field(default_factory=list)  # e.g. ["wave_state", "labor_state"]
 
 
 # ── Turn / Conversation store models ─────────────────────────────────────────
@@ -151,7 +165,8 @@ class CopilotTurnResponse(BaseModel):
     evidence: list[dict] | None = None
     neighborhood: dict | None = None
     agent: str | None = None
-    skills_used: list[str] | None = None
+    skills_used: list[str] | None = None       # actually invoked — [] for ASK
+    skills_available: list[str] | None = None  # agent-reported reachable capabilities
     model_id: str | None = None
     reasoning_level: str | None = None
     routing_rule: str | None = None
@@ -159,6 +174,8 @@ class CopilotTurnResponse(BaseModel):
     latency_ms: float | None = None
     degraded: bool = False
     degradation_reason: str | None = None
+    answerability: str = "answerable"   # "answerable" | "insufficient_evidence" | "partial"
+    missing_context: list[str] = Field(default_factory=list)
 
     # Future: ANALYZE and ACT fields populated in 15C / 15D
     related_artifacts: dict = Field(default_factory=dict)

--- a/apps/api/maiw_api/copilot/service.py
+++ b/apps/api/maiw_api/copilot/service.py
@@ -116,18 +116,90 @@ class CopilotService:
         await self._publish("COPILOT_INTENT_RESOLVED", "intent=ASK", trace_id=trace_id)
 
         # ── Assemble WarehouseState ───────────────────────────────────────────
+        _t_state = time.monotonic()
         state, state_degraded, state_degradation_reason = await self._get_state(
             warehouse_id=warehouse_id,
             scenario_name=scenario_name,
             trace_id=trace_id,
         )
+        _state_ms = (time.monotonic() - _t_state) * 1000
 
-        # ── Resolve Operational Graph neighborhood ────────────────────────────
+        # ── Early answerability check — skip graph lookup if state is missing ─
+        missing = _missing_context(state, scenario_name)
+
+        if state is None or missing:
+            # Build a null neighborhood — no graph lookup needed
+            from maiw_api.copilot.models import ContextNeighborhood as _CN
+            neighborhood = _CN(
+                focus_entity_id=None,
+                focus_entity_label=None,
+                entity_ids=[],
+                relationship_summary={},
+                max_depth=2,
+                graph_available=False,
+            )
+            degradation = _build_degradation(state_degradation_reason, missing, neighborhood)
+            if state is None:
+                answer = (
+                    f"I cannot determine the answer because warehouse state is unavailable"
+                    f" for scenario '{scenario_name or warehouse_id}'. "
+                    + (state_degradation_reason or "")
+                ).strip()
+                routing_reason = "State unavailable — skipped"
+            else:
+                domain_str = ", ".join(missing)
+                answer = (
+                    f"I cannot determine the answer because the following context is unavailable: "
+                    f"{domain_str}. This usually means the scenario has not been started or "
+                    f"the requested data has not been loaded into the runtime."
+                )
+                routing_reason = "Answerability gate — empty state refused"
+            result = CopilotAskResult(
+                answer=answer,
+                evidence=[],
+                neighborhood=neighborhood,
+                agent="OperationsCoordinationAgent",
+                skills_used=[],
+                skills_available=[],
+                model_id="none",
+                reasoning_level="MEDIUM",
+                routing_rule="none",
+                routing_reason=routing_reason,
+                trace_id=trace_id,
+                snapshot_id="none",
+                warehouse_id=warehouse_id,
+                latency_ms=(time.monotonic() - _t0) * 1000,
+                degraded=True,
+                degradation_reason=degradation,
+                answerability="insufficient_evidence",
+                missing_context=missing,
+                timing={
+                    "state_assembly_ms": round(_state_ms, 1),
+                    "graph_lookup_ms": 0.0,
+                    "model_inference_ms": 0.0,
+                    "total_ms": round((time.monotonic() - _t0) * 1000, 1),
+                },
+            )
+            turn = self._make_turn(
+                turn_id=turn_id,
+                conv_id=conv.conversation_id,
+                message=message,
+                intent=intent,
+                trace_id=trace_id,
+                result=result,
+            )
+            self._store.add_turn(turn)
+            await self._publish("COPILOT_TURN_COMPLETE", "degraded=true insufficient_evidence", trace_id=trace_id)
+            return result, turn
+
+        # ── Resolve Operational Graph neighborhood (only when state is present) ─
+        _t_graph = time.monotonic()
         neighborhood = context_resolver.resolve(
             question=message,
             warehouse_id=warehouse_id,
             graph=self._graph,
         )
+        _graph_ms = (time.monotonic() - _t_graph) * 1000
 
         await self._publish(
             "COPILOT_CONTEXT_RESOLVED",
@@ -136,87 +208,6 @@ class CopilotService:
             f"graph_available={neighborhood.graph_available}",
             trace_id=trace_id,
         )
-
-        # ── Degrade if state is entirely unavailable ──────────────────────────
-        missing = _missing_context(state, scenario_name)
-
-        if state is None:
-            degradation = _build_degradation(state_degradation_reason, missing, neighborhood)
-            result = CopilotAskResult(
-                answer=(
-                    f"I cannot determine the answer because warehouse state is unavailable"
-                    f" for scenario '{scenario_name or warehouse_id}'. "
-                    + (state_degradation_reason or "")
-                ).strip(),
-                evidence=[],
-                neighborhood=neighborhood,
-                agent="OperationsCoordinationAgent",
-                skills_used=[],
-                skills_available=[],
-                model_id="none",
-                reasoning_level="MEDIUM",
-                routing_rule="none",
-                routing_reason="State unavailable — skipped",
-                trace_id=trace_id,
-                snapshot_id="none",
-                warehouse_id=warehouse_id,
-                latency_ms=(time.monotonic() - _t0) * 1000,
-                degraded=True,
-                degradation_reason=degradation,
-                answerability="insufficient_evidence",
-                missing_context=missing,
-            )
-            turn = self._make_turn(
-                turn_id=turn_id,
-                conv_id=conv.conversation_id,
-                message=message,
-                intent=intent,
-                trace_id=trace_id,
-                result=result,
-            )
-            self._store.add_turn(turn)
-            await self._publish("COPILOT_TURN_COMPLETE", "degraded=true insufficient_evidence", trace_id=trace_id)
-            return result, turn
-
-        # ── Answerability gate — refuse to call Nemotron on empty/zero state ──
-        if missing:
-            degradation = _build_degradation(state_degradation_reason, missing, neighborhood)
-            domain_str = ", ".join(missing)
-            result = CopilotAskResult(
-                answer=(
-                    f"I cannot determine the answer because the following context is unavailable: "
-                    f"{domain_str}. This usually means the scenario has not been started or "
-                    f"the requested data has not been loaded into the runtime."
-                ),
-                evidence=[],
-                neighborhood=neighborhood,
-                agent="OperationsCoordinationAgent",
-                skills_used=[],
-                skills_available=[],
-                model_id="none",
-                reasoning_level="MEDIUM",
-                routing_rule="none",
-                routing_reason="Answerability gate — empty state refused",
-                trace_id=trace_id,
-                snapshot_id="none",
-                warehouse_id=warehouse_id,
-                latency_ms=(time.monotonic() - _t0) * 1000,
-                degraded=True,
-                degradation_reason=degradation,
-                answerability="insufficient_evidence",
-                missing_context=missing,
-            )
-            turn = self._make_turn(
-                turn_id=turn_id,
-                conv_id=conv.conversation_id,
-                message=message,
-                intent=intent,
-                trace_id=trace_id,
-                result=result,
-            )
-            self._store.add_turn(turn)
-            await self._publish("COPILOT_TURN_COMPLETE", "degraded=true insufficient_evidence", trace_id=trace_id)
-            return result, turn
 
         # ── Seal snapshot and call agent ──────────────────────────────────────
         try:
@@ -267,6 +258,7 @@ class CopilotService:
             return result, turn
 
         # ── Build structured evidence from assessment facts ───────────────────
+        _total_ms = (time.monotonic() - _t0) * 1000
         evidence = _facts_to_evidence(assessment.facts_observed, assessment.severity)
 
         # Collect all degradation reasons: state domains + graph availability
@@ -288,11 +280,17 @@ class CopilotService:
             trace_id=trace_id,
             snapshot_id=assessment.snapshot_id,
             warehouse_id=assessment.warehouse_id,
-            latency_ms=assessment.latency_ms,
+            latency_ms=_total_ms,
             degraded=bool(full_degradation),
             degradation_reason=full_degradation or None,
             answerability=answerability,
             missing_context=partial_missing,
+            timing={
+                "state_assembly_ms": round(_state_ms, 1),
+                "graph_lookup_ms": round(_graph_ms, 1),
+                "model_inference_ms": round(assessment.latency_ms, 1),
+                "total_ms": round(_total_ms, 1),
+            },
         )
 
         turn = self._make_turn(

--- a/apps/api/maiw_api/copilot/service.py
+++ b/apps/api/maiw_api/copilot/service.py
@@ -27,6 +27,7 @@ CopilotService: if we cannot inject real state, we degrade explicitly.
 from __future__ import annotations
 
 import logging
+import time
 import uuid
 from datetime import datetime, timezone
 from typing import Any
@@ -100,6 +101,7 @@ class CopilotService:
 
         Zero ActionProposals, zero DecisionEngine evaluations, zero writes.
         """
+        _t0 = time.monotonic()
         trace_id = str(uuid.uuid4())
         turn_id = str(uuid.uuid4())
 
@@ -158,7 +160,7 @@ class CopilotService:
                 trace_id=trace_id,
                 snapshot_id="none",
                 warehouse_id=warehouse_id,
-                latency_ms=0.0,
+                latency_ms=(time.monotonic() - _t0) * 1000,
                 degraded=True,
                 degradation_reason=degradation,
                 answerability="insufficient_evidence",
@@ -198,7 +200,7 @@ class CopilotService:
                 trace_id=trace_id,
                 snapshot_id="none",
                 warehouse_id=warehouse_id,
-                latency_ms=0.0,
+                latency_ms=(time.monotonic() - _t0) * 1000,
                 degraded=True,
                 degradation_reason=degradation,
                 answerability="insufficient_evidence",
@@ -246,7 +248,7 @@ class CopilotService:
                 trace_id=trace_id,
                 snapshot_id="none",
                 warehouse_id=warehouse_id,
-                latency_ms=0.0,
+                latency_ms=(time.monotonic() - _t0) * 1000,
                 degraded=True,
                 degradation_reason=str(exc),
                 answerability="insufficient_evidence",
@@ -452,12 +454,12 @@ def _build_degradation(
     """Compose a single degradation_reason string covering all missing context."""
     parts = []
     if state_reason:
-        parts.append(state_reason)
+        parts.append(state_reason.rstrip("."))
     if missing:
-        parts.append(f"Missing state domains: {', '.join(missing)}.")
+        parts.append(f"Missing state domains: {', '.join(missing)}")
     if neighborhood is not None and not getattr(neighborhood, "graph_available", True):
-        parts.append("Operational Graph unavailable — neighborhood context not shown.")
-    return "; ".join(parts) if parts else None
+        parts.append("Operational Graph unavailable — neighborhood context not shown")
+    return ". ".join(parts) + "." if parts else None
 
 
 # ── Evidence extraction ───────────────────────────────────────────────────────

--- a/apps/api/maiw_api/copilot/service.py
+++ b/apps/api/maiw_api/copilot/service.py
@@ -116,6 +116,7 @@ class CopilotService:
         # ── Assemble WarehouseState ───────────────────────────────────────────
         state, state_degraded, state_degradation_reason = await self._get_state(
             warehouse_id=warehouse_id,
+            scenario_name=scenario_name,
             trace_id=trace_id,
         )
 
@@ -135,16 +136,21 @@ class CopilotService:
         )
 
         # ── Degrade if state is entirely unavailable ──────────────────────────
+        missing = _missing_context(state, scenario_name)
+
         if state is None:
+            degradation = _build_degradation(state_degradation_reason, missing, neighborhood)
             result = CopilotAskResult(
                 answer=(
-                    "I cannot answer this question right now. "
-                    + (state_degradation_reason or "Warehouse state is unavailable.")
-                ),
+                    f"I cannot determine the answer because warehouse state is unavailable"
+                    f" for scenario '{scenario_name or warehouse_id}'. "
+                    + (state_degradation_reason or "")
+                ).strip(),
                 evidence=[],
                 neighborhood=neighborhood,
                 agent="OperationsCoordinationAgent",
                 skills_used=[],
+                skills_available=[],
                 model_id="none",
                 reasoning_level="MEDIUM",
                 routing_rule="none",
@@ -154,7 +160,9 @@ class CopilotService:
                 warehouse_id=warehouse_id,
                 latency_ms=0.0,
                 degraded=True,
-                degradation_reason=state_degradation_reason,
+                degradation_reason=degradation,
+                answerability="insufficient_evidence",
+                missing_context=missing,
             )
             turn = self._make_turn(
                 turn_id=turn_id,
@@ -165,7 +173,47 @@ class CopilotService:
                 result=result,
             )
             self._store.add_turn(turn)
-            await self._publish("COPILOT_TURN_COMPLETE", "degraded=true", trace_id=trace_id)
+            await self._publish("COPILOT_TURN_COMPLETE", "degraded=true insufficient_evidence", trace_id=trace_id)
+            return result, turn
+
+        # ── Answerability gate — refuse to call Nemotron on empty/zero state ──
+        if missing:
+            degradation = _build_degradation(state_degradation_reason, missing, neighborhood)
+            domain_str = ", ".join(missing)
+            result = CopilotAskResult(
+                answer=(
+                    f"I cannot determine the answer because the following context is unavailable: "
+                    f"{domain_str}. This usually means the scenario has not been started or "
+                    f"the requested data has not been loaded into the runtime."
+                ),
+                evidence=[],
+                neighborhood=neighborhood,
+                agent="OperationsCoordinationAgent",
+                skills_used=[],
+                skills_available=[],
+                model_id="none",
+                reasoning_level="MEDIUM",
+                routing_rule="none",
+                routing_reason="Answerability gate — empty state refused",
+                trace_id=trace_id,
+                snapshot_id="none",
+                warehouse_id=warehouse_id,
+                latency_ms=0.0,
+                degraded=True,
+                degradation_reason=degradation,
+                answerability="insufficient_evidence",
+                missing_context=missing,
+            )
+            turn = self._make_turn(
+                turn_id=turn_id,
+                conv_id=conv.conversation_id,
+                message=message,
+                intent=intent,
+                trace_id=trace_id,
+                result=result,
+            )
+            self._store.add_turn(turn)
+            await self._publish("COPILOT_TURN_COMPLETE", "degraded=true insufficient_evidence", trace_id=trace_id)
             return result, turn
 
         # ── Seal snapshot and call agent ──────────────────────────────────────
@@ -190,6 +238,7 @@ class CopilotService:
                 neighborhood=neighborhood,
                 agent="OperationsCoordinationAgent",
                 skills_used=[],
+                skills_available=[],
                 model_id="none",
                 reasoning_level="MEDIUM",
                 routing_rule="none",
@@ -200,6 +249,8 @@ class CopilotService:
                 latency_ms=0.0,
                 degraded=True,
                 degradation_reason=str(exc),
+                answerability="insufficient_evidence",
+                missing_context=[],
             )
             turn = self._make_turn(
                 turn_id=turn_id,
@@ -216,20 +267,18 @@ class CopilotService:
         # ── Build structured evidence from assessment facts ───────────────────
         evidence = _facts_to_evidence(assessment.facts_observed, assessment.severity)
 
-        # Add explicit note if domains were degraded
-        full_degradation = state_degradation_reason
-        if neighborhood.graph_available is False:
-            note = "Operational Graph unavailable — neighborhood context not shown."
-            full_degradation = (
-                f"{full_degradation}; {note}" if full_degradation else note
-            )
+        # Collect all degradation reasons: state domains + graph availability
+        full_degradation = _build_degradation(state_degradation_reason, [], neighborhood)
+        partial_missing = [m for m in _missing_context(state, scenario_name)]
+        answerability = "partial" if (state_degradation_reason or not neighborhood.graph_available) else "answerable"
 
         result = CopilotAskResult(
             answer=assessment.summary,
             evidence=evidence,
             neighborhood=neighborhood,
             agent="OperationsCoordinationAgent",
-            skills_used=assessment.skills_consulted,
+            skills_used=[],                              # ASK invokes no tools
+            skills_available=assessment.skills_consulted,
             model_id=assessment.model_id,
             reasoning_level="MEDIUM",
             routing_rule=assessment.routing_rule,
@@ -240,6 +289,8 @@ class CopilotService:
             latency_ms=assessment.latency_ms,
             degraded=bool(full_degradation),
             degradation_reason=full_degradation or None,
+            answerability=answerability,
+            missing_context=partial_missing,
         )
 
         turn = self._make_turn(
@@ -260,6 +311,7 @@ class CopilotService:
         self,
         warehouse_id: str,
         trace_id: str,
+        scenario_name: str = "",
     ) -> tuple[Any | None, bool, str | None]:
         """
         Assemble WarehouseState. Returns (state, degraded, degradation_reason).
@@ -338,6 +390,74 @@ class CopilotService:
             response_summary=result.answer[:200],
             artifact_refs={},
         )
+
+
+# ── Answerability helpers ─────────────────────────────────────────────────────
+
+def _missing_context(state: Any | None, scenario_name: str) -> list[str]:
+    """
+    Return the list of context items that are absent or functionally empty.
+
+    A domain is "missing" if:
+    - state is None (completely unavailable), OR
+    - the domain attribute is None, OR
+    - all key numeric fields are zero (serialized absence, not legitimate empty)
+
+    Distinguishes empty-but-successful (legitimate zero records) from
+    unavailable (provider failed or scenario not loaded).
+
+    "Functionally empty" = all key counters are zero AND scenario_name is
+    provided but apparently not loaded. A real warehouse always has some
+    equipment, workers, or wave records; total-zero across all three domains
+    indicates the scenario was not loaded into the runtime.
+    """
+    if state is None:
+        return ["wave_state", "labor_state", "equipment_state"]
+
+    missing = []
+
+    # Check each domain: None attribute = missing
+    if getattr(state, "waves", None) is None:
+        missing.append("wave_state")
+    if getattr(state, "labor", None) is None:
+        missing.append("labor_state")
+    if getattr(state, "equipment", None) is None:
+        missing.append("equipment_state")
+
+    if missing:
+        return missing
+
+    # If all three domains are present but all counters are zero, treat as
+    # functionally unavailable — scenario not loaded into runtime.
+    waves = state.waves
+    labor = state.labor
+    equipment = state.equipment
+
+    wave_total = getattr(waves, "total_waves", None) or getattr(waves, "total_tasks", None) or 0
+    labor_total = getattr(labor, "total_workers", None) or getattr(labor, "total_labor", None) or 0
+    equip_total = getattr(equipment, "total_equipment", None) or getattr(equipment, "total", None) or 0
+
+    if wave_total == 0 and labor_total == 0 and equip_total == 0:
+        # All zeros across all three domains = scenario not loaded
+        return ["wave_state", "labor_state", "equipment_state"]
+
+    return missing
+
+
+def _build_degradation(
+    state_reason: str | None,
+    missing: list[str],
+    neighborhood: Any,
+) -> str | None:
+    """Compose a single degradation_reason string covering all missing context."""
+    parts = []
+    if state_reason:
+        parts.append(state_reason)
+    if missing:
+        parts.append(f"Missing state domains: {', '.join(missing)}.")
+    if neighborhood is not None and not getattr(neighborhood, "graph_available", True):
+        parts.append("Operational Graph unavailable — neighborhood context not shown.")
+    return "; ".join(parts) if parts else None
 
 
 # ── Evidence extraction ───────────────────────────────────────────────────────

--- a/apps/api/maiw_api/routers/copilot.py
+++ b/apps/api/maiw_api/routers/copilot.py
@@ -97,5 +97,6 @@ async def copilot_turn(body: CopilotTurnRequest, request: Request):
         degradation_reason=result.degradation_reason,
         answerability=result.answerability,
         missing_context=result.missing_context,
+        timing=result.timing,
         related_artifacts={},
     )

--- a/apps/api/maiw_api/routers/copilot.py
+++ b/apps/api/maiw_api/routers/copilot.py
@@ -87,6 +87,7 @@ async def copilot_turn(body: CopilotTurnRequest, request: Request):
         },
         agent=result.agent,
         skills_used=result.skills_used,
+        skills_available=result.skills_available,
         model_id=result.model_id,
         reasoning_level=result.reasoning_level,
         routing_rule=result.routing_rule,
@@ -94,5 +95,7 @@ async def copilot_turn(body: CopilotTurnRequest, request: Request):
         latency_ms=result.latency_ms,
         degraded=result.degraded,
         degradation_reason=result.degradation_reason,
+        answerability=result.answerability,
+        missing_context=result.missing_context,
         related_artifacts={},
     )

--- a/apps/api/tests/test_copilot_ask.py
+++ b/apps/api/tests/test_copilot_ask.py
@@ -47,8 +47,19 @@ from maiw_api.copilot.store import InMemoryCopilotStore
 
 @dataclass
 class _FakeDomainState:
-    """Non-None placeholder so _get_state doesn't flag domains as missing."""
-    pass
+    """
+    Non-None domain state with non-zero counters so _missing_context()
+    treats this as a loaded scenario (not functionally empty).
+    """
+    # Wave domain attributes
+    total_waves: int = 3
+    total_tasks: int = 120
+    # Labor domain attributes
+    total_workers: int = 120
+    total_labor: int = 120
+    # Equipment domain attributes
+    total_equipment: int = 24
+    total: int = 24
 
 
 @dataclass
@@ -664,3 +675,182 @@ class TestAskResultContract:
         assert "scratchpad" not in fields
         assert "hidden_reasoning" not in fields
         assert "reasoning_tokens" not in fields
+
+
+# ── 11. Answerability gate — release-blocking tests ───────────────────────────
+
+from maiw_api.copilot.service import _missing_context, _build_degradation
+
+
+class _ZeroDomainState:
+    """Domain state object with all-zero counters — simulates an unloaded scenario."""
+    total_waves: int = 0
+    total_tasks: int = 0
+    total_workers: int = 0
+    total_labor: int = 0
+    total_equipment: int = 0
+    total: int = 0
+
+
+@dataclass
+class _AllZeroState:
+    """State where every domain is present but all counters are zero."""
+    warehouse_id: str = "DC-47"
+    equipment: Any = None
+    labor: Any = None
+    waves: Any = None
+
+    def __post_init__(self):
+        if self.equipment is None:
+            self.equipment = _ZeroDomainState()
+        if self.labor is None:
+            self.labor = _ZeroDomainState()
+        if self.waves is None:
+            self.waves = _ZeroDomainState()
+
+
+class TestAnswerabilityGate:
+    """Release-blocking answerability tests from Phase 15B review."""
+
+    def test_missing_wave_state_never_produces_zero_total(self):
+        """If wave_state is absent, _missing_context must flag it — not report 0 total."""
+        state = _AllZeroState()
+        missing = _missing_context(state, "wave_disruption")
+        assert "wave_state" in missing, "All-zero state must be flagged as missing"
+
+    def test_missing_warehouse_state_returns_no_causal_claim(self):
+        """If state is None, ASK must refuse to produce a causal answer."""
+        missing = _missing_context(None, "wave_disruption")
+        assert "wave_state" in missing
+        assert "labor_state" in missing
+        assert "equipment_state" in missing
+
+    @pytest.mark.asyncio
+    async def test_all_zero_state_does_not_call_nemotron(self):
+        """Answerability gate must refuse to call the agent when state is all-zero."""
+        agent = MagicMock()
+        agent.analyze_disruption = AsyncMock()
+
+        provider = MagicMock()
+        provider.get_state = AsyncMock(return_value=_AllZeroState())
+
+        svc = CopilotService(
+            operations_agent=agent,
+            state_provider=provider,
+        )
+        result, _ = await svc.ask(
+            message="Why is Wave 17 at risk?",
+            conversation_id=None,
+            warehouse_id="DC-47",
+            scenario_name="wave_disruption",
+        )
+
+        agent.analyze_disruption.assert_not_called()
+        assert result.answerability == "insufficient_evidence"
+        assert result.degraded is True
+        assert "wave_state" in result.missing_context
+
+    @pytest.mark.asyncio
+    async def test_all_zero_state_produces_no_causal_claim(self):
+        """Zero-state response must not contain fabricated causal conclusions."""
+        provider = MagicMock()
+        provider.get_state = AsyncMock(return_value=_AllZeroState())
+
+        svc = CopilotService(
+            operations_agent=MagicMock(),
+            state_provider=provider,
+        )
+        result, _ = await svc.ask(
+            message="Why is Wave 17 at risk?",
+            conversation_id=None,
+            warehouse_id="DC-47",
+            scenario_name="wave_disruption",
+        )
+
+        # Must not contain invented operational conclusions
+        assert "no operational activity" not in result.answer.lower()
+        assert "complete absence" not in result.answer.lower()
+
+    def test_empty_successful_state_is_not_flagged(self):
+        """
+        A state with legitimate non-zero data must NOT be flagged as missing.
+        Distinguishes empty-but-successful from unavailable.
+        """
+        missing = _missing_context(_FakeState(), "wave_disruption")
+        assert missing == [], f"Loaded state should not be flagged; got {missing}"
+
+    @pytest.mark.asyncio
+    async def test_graph_unavailable_plus_valid_state_still_answers(self):
+        """Graph unavailable + valid state = partial answer, not refused."""
+        with patch("maiw_api.copilot.service.WarehouseStateSnapshot") as mock_snap:
+            mock_snap.seal.return_value = _FakeSnapshot.seal(_FakeState())
+            svc = _make_service(include_graph=False)  # graph=None
+            result, _ = await svc.ask(
+                message="Why is Wave 17 at risk?",
+                conversation_id=None,
+                warehouse_id="DC-47",
+            )
+
+        # Should answer (agent called), just with degraded=True for graph
+        assert result.answer == "Wave 17 is primarily constrained by labor availability."
+        assert result.answerability in ("answerable", "partial")
+        assert result.neighborhood.graph_available is False
+
+    def test_skills_used_empty_for_ask(self):
+        """ASK turns invoke no tools; skills_used must always be empty."""
+        from maiw_api.copilot.models import CopilotAskResult, ContextNeighborhood
+        neighborhood = ContextNeighborhood(
+            focus_entity_id=None, focus_entity_label=None,
+            entity_ids=[], relationship_summary={}, max_depth=2, graph_available=False,
+        )
+        result = CopilotAskResult(
+            answer="test",
+            evidence=[],
+            neighborhood=neighborhood,
+            agent="OperationsCoordinationAgent",
+            skills_used=[],
+            skills_available=["warehouse.wave.get_state"],
+            model_id="none",
+            reasoning_level="MEDIUM",
+            routing_rule="none",
+            routing_reason="test",
+            trace_id="t1",
+            snapshot_id="s1",
+            warehouse_id="DC-47",
+            latency_ms=0.0,
+        )
+        assert result.skills_used == []
+        assert "warehouse.wave.get_state" in result.skills_available
+
+    @pytest.mark.asyncio
+    async def test_skills_used_is_empty_in_ask_response(self):
+        """Service must return skills_used=[] for ASK turns."""
+        with patch("maiw_api.copilot.service.WarehouseStateSnapshot") as mock_snap:
+            mock_snap.seal.return_value = _FakeSnapshot.seal(_FakeState())
+            svc = _make_service()
+            result, _ = await svc.ask(
+                message="Why is Wave 17 at risk?",
+                conversation_id=None,
+                warehouse_id="DC-47",
+            )
+
+        assert result.skills_used == [], "ASK must report no invoked tools"
+        assert isinstance(result.skills_available, list)
+
+    def test_degradation_reason_includes_all_missing_domains(self):
+        """_build_degradation must expose missing state domains, not only graph."""
+        from maiw_api.copilot.service import _build_degradation
+        from maiw_api.copilot.models import ContextNeighborhood
+
+        neighborhood = ContextNeighborhood(
+            focus_entity_id=None, focus_entity_label=None,
+            entity_ids=[], relationship_summary={}, max_depth=2, graph_available=False,
+        )
+        reason = _build_degradation(
+            "Provider failed.",
+            ["wave_state", "labor_state"],
+            neighborhood,
+        )
+        assert "wave_state" in reason
+        assert "labor_state" in reason
+        assert "Operational Graph" in reason


### PR DESCRIPTION
## Description

Fixes semantic correctness failures found during Phase 15B review. The Copilot ASK endpoint was passing all-zero warehouse state to Nemotron when a scenario was not loaded, producing fabricated causal answers. This PR adds an answerability gate, separates invoked skills from available capabilities, exposes all missing state domains in the degradation response, skips the graph lookup on missing state, and adds a per-turn timing breakdown.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Performance improvement

## Related Issues
Follows PR #85 (Phase 15B Copilot ASK implementation). No external issue number.

## Changes Made
- [x] Answerability gate: all-zero state across all three domains (equipment, labor, waves) is treated as "scenario not loaded" — Nemotron is never called; response returns `answerability: "insufficient_evidence"` with explicit `missing_context` list
- [x] Graph lookup skipped when state is missing — eliminates ~1s graph timeout before the gate fires
- [x] `skills_used` is always `[]` for ASK turns (no tools invoked); `skills_available` carries agent-reported reachable capabilities
- [x] `degradation_reason` now exposes all missing state domains, not only graph availability
- [x] `answerability` field added: `"answerable"` | `"insufficient_evidence"` | `"partial"`
- [x] `missing_context` field added: list of unavailable domain names (e.g. `["wave_state", "labor_state", "equipment_state"]`)
- [x] `timing` breakdown added: `state_assembly_ms`, `graph_lookup_ms`, `model_inference_ms`, `total_ms`
- [x] `latency_ms` on all paths now reflects actual end-to-end wall time from start of `ask()`
- [x] `degradation_reason` punctuation fixed (was producing `equipment_state.;`)
- [x] 9 new blocking tests in `TestAnswerabilityGate`

## Testing
- [x] Unit tests pass — 50/50 Copilot ASK tests (41 original + 9 new blocking tests)
- [x] Integration tests pass — 990 CORE CI, 258 maiw-world + API
- [x] Manual testing completed — confirmed `answerability: "insufficient_evidence"` with `model_id: "none"` when scenario is not loaded

## Screenshots (if applicable)
N/A — API-only change.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Deployment Notes
No new environment variables. No schema migrations. Restart the API after merging to pick up the updated `CopilotService` logic.

## Breaking Changes
None. `skills_available` is a new field (additive). `skills_used` was previously populated with available capabilities — it now correctly returns `[]` for ASK turns, which is a behavioral correction, not a breaking contract change.