### PR TITLE
fix(copilot): skip graph lookup on missing state; add timing breakdown

### DIFF
--- a/apps/api/maiw_api/copilot/models.py
+++ b/apps/api/maiw_api/copilot/models.py
@@ -90,6 +90,7 @@ class CopilotAskResult:
     degradation_reason: str | None = None
     answerability: str = "answerable"          # "answerable" | "insufficient_evidence" | "partial"
     missing_context: list[str] = field(default_factory=list)  # e.g. ["wave_state", "labor_state"]
+    timing: dict[str, float] = field(default_factory=dict)   # state_assembly_ms, graph_lookup_ms, model_inference_ms, total_ms
 
 
 # ── Turn / Conversation store models ─────────────────────────────────────────
@@ -176,6 +177,7 @@ class CopilotTurnResponse(BaseModel):
     degradation_reason: str | None = None
     answerability: str = "answerable"   # "answerable" | "insufficient_evidence" | "partial"
     missing_context: list[str] = Field(default_factory=list)
+    timing: dict = Field(default_factory=dict)  # state_assembly_ms, graph_lookup_ms, model_inference_ms, total_ms
 
     # Future: ANALYZE and ACT fields populated in 15C / 15D
     related_artifacts: dict = Field(default_factory=dict)

--- a/apps/api/maiw_api/copilot/service.py
+++ b/apps/api/maiw_api/copilot/service.py
@@ -116,18 +116,90 @@ class CopilotService:
         await self._publish("COPILOT_INTENT_RESOLVED", "intent=ASK", trace_id=trace_id)
 
         # ── Assemble WarehouseState ───────────────────────────────────────────
+        _t_state = time.monotonic()
         state, state_degraded, state_degradation_reason = await self._get_state(
             warehouse_id=warehouse_id,
             scenario_name=scenario_name,
             trace_id=trace_id,
         )
+        _state_ms = (time.monotonic() - _t_state) * 1000
 
-        # ── Resolve Operational Graph neighborhood ────────────────────────────
+        # ── Early answerability check — skip graph lookup if state is missing ─
+        missing = _missing_context(state, scenario_name)
+
+        if state is None or missing:
+            # Build a null neighborhood — no graph lookup needed
+            from maiw_api.copilot.models import ContextNeighborhood as _CN
+            neighborhood = _CN(
+                focus_entity_id=None,
+                focus_entity_label=None,
+                entity_ids=[],
+                relationship_summary={},
+                max_depth=2,
+                graph_available=False,
+            )
+            degradation = _build_degradation(state_degradation_reason, missing, neighborhood)
+            if state is None:
+                answer = (
+                    f"I cannot determine the answer because warehouse state is unavailable"
+                    f" for scenario '{scenario_name or warehouse_id}'. "
+                    + (state_degradation_reason or "")
+                ).strip()
+                routing_reason = "State unavailable — skipped"
+            else:
+                domain_str = ", ".join(missing)
+                answer = (
+                    f"I cannot determine the answer because the following context is unavailable: "
+                    f"{domain_str}. This usually means the scenario has not been started or "
+                    f"the requested data has not been loaded into the runtime."
+                )
+                routing_reason = "Answerability gate — empty state refused"
+            result = CopilotAskResult(
+                answer=answer,
+                evidence=[],
+                neighborhood=neighborhood,
+                agent="OperationsCoordinationAgent",
+                skills_used=[],
+                skills_available=[],
+                model_id="none",
+                reasoning_level="MEDIUM",
+                routing_rule="none",
+                routing_reason=routing_reason,
+                trace_id=trace_id,
+                snapshot_id="none",
+                warehouse_id=warehouse_id,
+                latency_ms=(time.monotonic() - _t0) * 1000,
+                degraded=True,
+                degradation_reason=degradation,
+                answerability="insufficient_evidence",
+                missing_context=missing,
+                timing={
+                    "state_assembly_ms": round(_state_ms, 1),
+                    "graph_lookup_ms": 0.0,
+                    "model_inference_ms": 0.0,
+                    "total_ms": round((time.monotonic() - _t0) * 1000, 1),
+                },
+            )
+            turn = self._make_turn(
+                turn_id=turn_id,
+                conv_id=conv.conversation_id,
+                message=message,
+                intent=intent,
+                trace_id=trace_id,
+                result=result,
+            )
+            self._store.add_turn(turn)
+            await self._publish("COPILOT_TURN_COMPLETE", "degraded=true insufficient_evidence", trace_id=trace_id)
+            return result, turn
+
+        # ── Resolve Operational Graph neighborhood (only when state is present) ─
+        _t_graph = time.monotonic()
         neighborhood = context_resolver.resolve(
             question=message,
             warehouse_id=warehouse_id,
             graph=self._graph,
         )
+        _graph_ms = (time.monotonic() - _t_graph) * 1000
 
         await self._publish(
             "COPILOT_CONTEXT_RESOLVED",
@@ -136,87 +208,6 @@ class CopilotService:
             f"graph_available={neighborhood.graph_available}",
             trace_id=trace_id,
         )
-
-        # ── Degrade if state is entirely unavailable ──────────────────────────
-        missing = _missing_context(state, scenario_name)
-
-        if state is None:
-            degradation = _build_degradation(state_degradation_reason, missing, neighborhood)
-            result = CopilotAskResult(
-                answer=(
-                    f"I cannot determine the answer because warehouse state is unavailable"
-                    f" for scenario '{scenario_name or warehouse_id}'. "
-                    + (state_degradation_reason or "")
-                ).strip(),
-                evidence=[],
-                neighborhood=neighborhood,
-                agent="OperationsCoordinationAgent",
-                skills_used=[],
-                skills_available=[],
-                model_id="none",
-                reasoning_level="MEDIUM",
-                routing_rule="none",
-                routing_reason="State unavailable — skipped",
-                trace_id=trace_id,
-                snapshot_id="none",
-                warehouse_id=warehouse_id,
-                latency_ms=(time.monotonic() - _t0) * 1000,
-                degraded=True,
-                degradation_reason=degradation,
-                answerability="insufficient_evidence",
-                missing_context=missing,
-            )
-            turn = self._make_turn(
-                turn_id=turn_id,
-                conv_id=conv.conversation_id,
-                message=message,
-                intent=intent,
-                trace_id=trace_id,
-                result=result,
-            )
-            self._store.add_turn(turn)
-            await self._publish("COPILOT_TURN_COMPLETE", "degraded=true insufficient_evidence", trace_id=trace_id)
-            return result, turn
-
-        # ── Answerability gate — refuse to call Nemotron on empty/zero state ──
-        if missing:
-            degradation = _build_degradation(state_degradation_reason, missing, neighborhood)
-            domain_str = ", ".join(missing)
-            result = CopilotAskResult(
-                answer=(
-                    f"I cannot determine the answer because the following context is unavailable: "
-                    f"{domain_str}. This usually means the scenario has not been started or "
-                    f"the requested data has not been loaded into the runtime."
-                ),
-                evidence=[],
-                neighborhood=neighborhood,
-                agent="OperationsCoordinationAgent",
-                skills_used=[],
-                skills_available=[],
-                model_id="none",
-                reasoning_level="MEDIUM",
-                routing_rule="none",
-                routing_reason="Answerability gate — empty state refused",
-                trace_id=trace_id,
-                snapshot_id="none",
-                warehouse_id=warehouse_id,
-                latency_ms=(time.monotonic() - _t0) * 1000,
-                degraded=True,
-                degradation_reason=degradation,
-                answerability="insufficient_evidence",
-                missing_context=missing,
-            )
-            turn = self._make_turn(
-                turn_id=turn_id,
-                conv_id=conv.conversation_id,
-                message=message,
-                intent=intent,
-                trace_id=trace_id,
-                result=result,
-            )
-            self._store.add_turn(turn)
-            await self._publish("COPILOT_TURN_COMPLETE", "degraded=true insufficient_evidence", trace_id=trace_id)
-            return result, turn
 
         # ── Seal snapshot and call agent ──────────────────────────────────────
         try:
@@ -267,6 +258,7 @@ class CopilotService:
             return result, turn
 
         # ── Build structured evidence from assessment facts ───────────────────
+        _total_ms = (time.monotonic() - _t0) * 1000
         evidence = _facts_to_evidence(assessment.facts_observed, assessment.severity)
 
         # Collect all degradation reasons: state domains + graph availability
@@ -288,11 +280,17 @@ class CopilotService:
             trace_id=trace_id,
             snapshot_id=assessment.snapshot_id,
             warehouse_id=assessment.warehouse_id,
-            latency_ms=assessment.latency_ms,
+            latency_ms=_total_ms,
             degraded=bool(full_degradation),
             degradation_reason=full_degradation or None,
             answerability=answerability,
             missing_context=partial_missing,
+            timing={
+                "state_assembly_ms": round(_state_ms, 1),
+                "graph_lookup_ms": round(_graph_ms, 1),
+                "model_inference_ms": round(assessment.latency_ms, 1),
+                "total_ms": round(_total_ms, 1),
+            },
         )
 
         turn = self._make_turn(

--- a/apps/api/maiw_api/routers/copilot.py
+++ b/apps/api/maiw_api/routers/copilot.py
@@ -97,5 +97,6 @@ async def copilot_turn(body: CopilotTurnRequest, request: Request):
         degradation_reason=result.degradation_reason,
         answerability=result.answerability,
         missing_context=result.missing_context,
+        timing=result.timing,
         related_artifacts={},
     )


### PR DESCRIPTION
Two fixes from Phase 15B-fix review:

1. Graph lookup now runs only when state is present and answerable. Previously, context_resolver.resolve() ran unconditionally and caused ~1s graph timeout before the answerability gate fired. Missing state now returns immediately with a null neighborhood (graph_available=false), keeping rejected-turn latency proportional to state assembly only.

2. Timing breakdown added to all response paths: timing.state_assembly_ms  — WarehouseState retrieval time
   timing.graph_lookup_ms    — Operational Graph BFS time (0 when skipped)
   timing.model_inference_ms — Nemotron call time (0 when gate refused)
   timing.total_ms           — end-to-end ask() wall time

   latency_ms on success now reflects actual end-to-end time, not only the model inference portion reported by assessment.latency_ms.

## Description

Fixes semantic correctness failures found during Phase 15B review. The Copilot ASK endpoint was passing all-zero warehouse state to Nemotron when a scenario was not loaded, producing fabricated causal answers. This PR adds an answerability gate, separates invoked skills from available capabilities, exposes all missing state domains in the degradation response, skips the graph lookup on missing state, and adds a per-turn timing breakdown.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Performance improvement

## Related Issues
Follows PR #85 (Phase 15B Copilot ASK implementation). No external issue number.

## Changes Made
- [x] Answerability gate: all-zero state across all three domains (equipment, labor, waves) is treated as "scenario not loaded" — Nemotron is never called; response returns `answerability: "insufficient_evidence"` with explicit `missing_context` list
- [x] Graph lookup skipped when state is missing — eliminates ~1s graph timeout before the gate fires
- [x] `skills_used` is always `[]` for ASK turns (no tools invoked); `skills_available` carries agent-reported reachable capabilities
- [x] `degradation_reason` now exposes all missing state domains, not only graph availability
- [x] `answerability` field added: `"answerable"` | `"insufficient_evidence"` | `"partial"`
- [x] `missing_context` field added: list of unavailable domain names (e.g. `["wave_state", "labor_state", "equipment_state"]`)
- [x] `timing` breakdown added: `state_assembly_ms`, `graph_lookup_ms`, `model_inference_ms`, `total_ms`
- [x] `latency_ms` on all paths now reflects actual end-to-end wall time from start of `ask()`
- [x] `degradation_reason` punctuation fixed (was producing `equipment_state.;`)
- [x] 9 new blocking tests in `TestAnswerabilityGate`

## Testing
- [x] Unit tests pass — 50/50 Copilot ASK tests (41 original + 9 new blocking tests)
- [x] Integration tests pass — 990 CORE CI, 258 maiw-world + API
- [x] Manual testing completed — confirmed `answerability: "insufficient_evidence"` with `model_id: "none"` when scenario is not loaded

## Screenshots (if applicable)
N/A — API-only change.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Deployment Notes
No new environment variables. No schema migrations. Restart the API after merging to pick up the updated `CopilotService` logic.

## Breaking Changes
None. `skills_available` is a new field (additive). `skills_used` was previously populated with available capabilities — it now correctly returns `[]` for ASK turns, which is a behavioral correction, not a breaking contract change.